### PR TITLE
Make syslog address and port properties optional

### DIFF
--- a/jobs/syslog_forwarder/templates/rsyslog.conf.erb
+++ b/jobs/syslog_forwarder/templates/rsyslog.conf.erb
@@ -4,16 +4,22 @@ syslog_address = nil
 syslog_port = nil
 syslog_transport = nil
 
-if_p('syslog.address', 'syslog.port', 'syslog.transport') do |address, port, transport|
-  syslog_address = address
-  syslog_port = port
-  syslog_transport = transport
-end.else do
-  syslog_storer = link('syslog_storer')
+# use syslog_storer properties by default
+if_link('syslog_storer') do |syslog_storer|
   syslog_address = syslog_storer.instances[0].address
   syslog_port = syslog_storer.p('syslog.port')
   syslog_transport = syslog_storer.p('syslog.transport')
 end
+
+# overwrite with specific syslog properties if all properties set
+if_p('syslog.address', 'syslog.port', 'syslog.transport') do |address, port, transport|
+  syslog_address = address
+  syslog_port = port
+  syslog_transport = transport
+end
+
+# if transport nil, use the spec default value
+syslog_transport ||= p('syslog.transport')
 
 %>
 
@@ -75,15 +81,17 @@ $ActionSendStreamDriverAuthMode x509/name                         # authenticate
 $ActionSendStreamDriverPermittedPeer <%= p('syslog.permitted_peer') %>
 <% end %>
 
-<% if syslog_transport == 'relp' %>
-$ModLoad omrelp
-*.* :omrelp:<%= syslog_address %>:<%= syslog_port %>;BoshLogTemplate
-<% elsif syslog_transport == 'udp' %>
-*.* @<%= syslog_address %>:<%= syslog_port %>;BoshLogTemplate
-<% elsif syslog_transport == 'tcp' %>
-*.* @@<%= syslog_address %>:<%= syslog_port %>;BoshLogTemplate
-<% else %>
-<% raise "only RELP, UDP, and TCP protocols are supported (was '#{syslog_transport}')" %>
+<% if !!syslog_address && !!syslog_port %>
+  <% if syslog_transport == 'relp' %>
+  $ModLoad omrelp
+  *.* :omrelp:<%= syslog_address %>:<%= syslog_port %>;BoshLogTemplate
+  <% elsif syslog_transport == 'udp' %>
+  *.* @<%= syslog_address %>:<%= syslog_port %>;BoshLogTemplate
+  <% elsif syslog_transport == 'tcp' %>
+  *.* @@<%= syslog_address %>:<%= syslog_port %>;BoshLogTemplate
+  <% else %>
+  <% raise "only RELP, UDP, and TCP protocols are supported (was '#{syslog_transport}')" %>
+  <% end %>
 <% end %>
 
 <% if p('syslog.fallback_servers').length > 0 %>

--- a/manifests/cloud-config-lite.yml
+++ b/manifests/cloud-config-lite.yml
@@ -1,0 +1,31 @@
+---
+networks:
+- name: compilation
+  type: manual
+  subnets:
+  - range: 10.244.2.0/24
+    gateway: 10.244.2.1
+    az: eu-west-1a
+
+- name: services
+  type: manual
+  subnets:
+  - range: 10.244.1.0/24
+    gateway: 10.244.1.1
+    az: eu-west-1a
+
+azs:
+- name: eu-west-1a
+
+vm_types:
+- name: m3.medium
+- name: c3.large
+
+disk_types: []
+
+compilation:
+  workers: 10
+  reuse_compilation_vms: true
+  network: compilation
+  az: eu-west-1a
+  vm_type: c3.large

--- a/manifests/optional-forwarding.yml
+++ b/manifests/optional-forwarding.yml
@@ -1,0 +1,35 @@
+name: optional-forwarding
+
+director_uuid: <%= `bosh status --uuid` %>
+
+releases:
+- name: syslog
+  version: latest
+
+stemcells:
+- alias: trusty
+  os: ubuntu-trusty
+  version: latest
+
+update:
+  canaries: 10
+  max_in_flight: 10
+  canary_watch_time: 30000-600000
+  update_watch_time: 5000-600000
+  serial: false
+
+instance_groups:
+- name: optional-forwarding
+  jobs:
+  - name: syslog_forwarder
+    release: syslog
+  instances: 1
+  azs: [eu-west-1a]
+  vm_type: m3.medium
+  stemcell: trusty
+  networks:
+  - name: services
+  properties:
+    syslog:
+      address:
+      port:


### PR DESCRIPTION
For .pivotal tiles that want to use this release and expose the syslog
address and port as optional properties, this is required for the
deployment to succeed.

[#130627651]

Signed-off-by: Gerhard Lazu glazu@pivotal.io
