### PR TITLE
Use modern syntax to configure omrelp/omfwd and Allow configure action parameters for rsyslog

### DIFF
--- a/jobs/syslog_forwarder/spec
+++ b/jobs/syslog_forwarder/spec
@@ -29,6 +29,10 @@ properties:
       port: 44312
       transport: tcp
 
+  syslog.action_parameters:
+    description: "Hash of custom parameters for rsyslog action. See http://www.rsyslog.com/doc/v8-stable/configuration/actions.html#general-action-parameters"
+    default: {}
+
   syslog.custom_rule:
     description: Custom rule for syslog event forwarder.
     default: ""

--- a/jobs/syslog_forwarder/templates/rsyslog.conf.erb
+++ b/jobs/syslog_forwarder/templates/rsyslog.conf.erb
@@ -15,6 +15,10 @@ end.else do
   syslog_transport = syslog_storer.p('syslog.transport')
 end
 
+def rendered_action_parameters
+  return p("syslog.action_parameters").map{|k,v| "#{k}=\"#{v}\""}.join(' ')
+end
+
 %>
 
 $ModLoad imuxsock                      # local message reception (rsyslog uses a datagram socket)
@@ -80,19 +84,22 @@ $ModLoad omrelp
 action(type="omrelp"
        target="<%= syslog_address %>"
        port="<%= syslog_port %>"
-       template="BoshLogTemplate")
+       template="BoshLogTemplate"
+       <%= rendered_action_parameters() %>)
 <% elsif syslog_transport == 'udp' %>
 action(type="omfwd"
        Protocol="udp"
        Target="<%= syslog_address %>"
        Port="<%= syslog_port %>"
-       template="BoshLogTemplate")
+       template="BoshLogTemplate"
+       <%= rendered_action_parameters() %>)
 <% elsif syslog_transport == 'tcp' %>
 action(type="omfwd"
        Protocol="tcp"
        Target="<%= syslog_address %>"
        Port="<%= syslog_port %>"
-       template="BoshLogTemplate")
+       template="BoshLogTemplate"
+       <%= rendered_action_parameters() %>)
 <% else %>
 <% raise "only RELP, UDP, and TCP protocols are supported (was '#{syslog_transport}')" %>
 <% end %>
@@ -110,13 +117,15 @@ $ModLoad omrelp
 action(type="omrelp"
        target="<%= syslog_fallback_address %>"
        port="<%= syslog_fallback_port %>"
-       template="BoshLogTemplate")
+       template="BoshLogTemplate"
+       <%= rendered_action_parameters() %>)
         <% elsif syslog_fallback_transport == 'tcp' %>
 action(type="omfwd"
        Protocol="tcp"
        Target="<%= syslog_fallback_address %>"
        Port="<%= syslog_fallback_port %>"
-       template="BoshLogTemplate")
+       template="BoshLogTemplate"
+       <%= rendered_action_parameters() %>)
         <% else %>
           <% raise "only RELP, and TCP protocols are supported for fallback servers (was '#{syslog_fallback_transport}')" %>
         <% end %>

--- a/jobs/syslog_forwarder/templates/rsyslog.conf.erb
+++ b/jobs/syslog_forwarder/templates/rsyslog.conf.erb
@@ -77,11 +77,22 @@ $ActionSendStreamDriverPermittedPeer <%= p('syslog.permitted_peer') %>
 
 <% if syslog_transport == 'relp' %>
 $ModLoad omrelp
-*.* :omrelp:<%= syslog_address %>:<%= syslog_port %>;BoshLogTemplate
+action(type="omrelp"
+       target="<%= syslog_address %>"
+       port="<%= syslog_port %>"
+       template="BoshLogTemplate")
 <% elsif syslog_transport == 'udp' %>
-*.* @<%= syslog_address %>:<%= syslog_port %>;BoshLogTemplate
+action(type="omfwd"
+       Protocol="udp"
+       Target="<%= syslog_address %>"
+       Port="<%= syslog_port %>"
+       template="BoshLogTemplate")
 <% elsif syslog_transport == 'tcp' %>
-*.* @@<%= syslog_address %>:<%= syslog_port %>;BoshLogTemplate
+action(type="omfwd"
+       Protocol="tcp"
+       Target="<%= syslog_address %>"
+       Port="<%= syslog_port %>"
+       template="BoshLogTemplate")
 <% else %>
 <% raise "only RELP, UDP, and TCP protocols are supported (was '#{syslog_transport}')" %>
 <% end %>
@@ -96,9 +107,16 @@ $ActionExecOnlyWhenPreviousIsSuspended on
         %>
         <% if syslog_fallback_transport == 'relp' %>
 $ModLoad omrelp
-:omrelp:<%= syslog_fallback_address %>:<%= syslog_fallback_port %>;BoshLogTemplate
+action(type="omrelp"
+       target="<%= syslog_fallback_address %>"
+       port="<%= syslog_fallback_port %>"
+       template="BoshLogTemplate")
         <% elsif syslog_fallback_transport == 'tcp' %>
-& @@<%= syslog_fallback_address %>:<%= syslog_fallback_port %>;BoshLogTemplate
+action(type="omfwd"
+       Protocol="tcp"
+       Target="<%= syslog_fallback_address %>"
+       Port="<%= syslog_fallback_port %>"
+       template="BoshLogTemplate")
         <% else %>
           <% raise "only RELP, and TCP protocols are supported for fallback servers (was '#{syslog_fallback_transport}')" %>
         <% end %>


### PR DESCRIPTION
The syslog forwarder configuration for the omrepl and omfwd modules uses the old configuration syntax.

We want to update it to the new syntax for several reasons:

 - in order to be able to configure additional settings, like `timeout` for `omrepl`[1], we need to convert it to the new syntax.

 - We are experiencing a issue when the RELP syslog server is behind an AWS ELB loadbalancer in TCP mode with healthchecks. When all the backends are down in the ELB, it will open the TCP connection and close it immediately. When that happens, rsyslog using omrelp with the old syntax does not exit when receiving a TERM signal.

   This causes the `service rsyslogd restart` executed from metron_agent ctl take 30 seconds, and the job metron_agent is marked as bad by monit.

 - It makes sense to use the new syntax

We also allow configure action parameters for rsyslog actions[1][2][3]

This would allow you to configure parameters like relp timeout, queue name, sizes, retries, etc. For example, it would make easier to configure forwarding to a rsyslog server behind a AWS ELB[4]

[1] http://www.rsyslog.com/doc/v8-stable/configuration/actions.html#general-action-parameters
[2] http://www.rsyslog.com/doc/v8-stable/configuration/modules/omfwd.html
[3] http://www.rsyslog.com/doc/v8-stable/configuration/modules/omrelp.html
[4] http://lists.adiscon.net/pipermail/rsyslog/2014-December/039270.html