### PR TITLE
Optionally configure log template format

### DIFF
--- a/jobs/syslog_forwarder/spec
+++ b/jobs/syslog_forwarder/spec
@@ -96,3 +96,11 @@ properties:
       directory with subdirectories containing log files.
       log lines will be tagged with subdirectory name.
     default: /var/vcap/sys/log
+
+  syslog.log_template:
+    description: |
+        Syslog log template to use when sending the messages:
+        - rfc3424: rfc3424 format: ' [bosh instance="deployment/jobname/job_id" ]'
+        - legacy: Legacy syslog-release format: 'deployment/jobname/job_id'
+        - metron_agent: compatible with loggregator/metron_agent format '[job=foo index=0]'
+    default: "rfc5424"

--- a/jobs/syslog_forwarder/templates/rsyslog.conf.erb
+++ b/jobs/syslog_forwarder/templates/rsyslog.conf.erb
@@ -15,6 +15,7 @@ end.else do
   syslog_transport = syslog_storer.p('syslog.transport')
 end
 
+syslog_log_template = p('syslog.log_template')
 %>
 
 $ModLoad imuxsock                      # local message reception (rsyslog uses a datagram socket)
@@ -53,7 +54,15 @@ template(name="BoshLogTemplate" type="list") {
   property(name="timestamp" dateFormat="rfc3339")
   constant(value=" <%= spec.address %> ")
   property(name="syslogtag")
+<% if syslog_log_template == 'rfc5424' %>
   constant(value=" [bosh instance=\"<%= spec.deployment %>/<%= spec.job.name %>/<%= spec.id %>\"] ")
+<% elsif syslog_log_template == 'legacy' %>
+  constant(value=" <%= spec.deployment %>/<%= spec.job.name %>/<%= spec.id %> ")
+<% elsif syslog_log_template == 'metron_agent' %>
+  constant(value=" [job=<%= name %> index=<%= spec.index.to_i %>] ")
+<% else %>
+<% raise "only 'rfc5434', 'legacy' and 'metron_agent' log templates are supported (was '#{syslog_log_template}')" %>
+<% end %>
   property(name="msg")
 }
 


### PR DESCRIPTION
The `metron_agent` syslog template[1] and the `syslog-release` template[2] are not equivalent. Also, the syslog_release one does not include the index number of the VM.

Beause that, if one replaces the  metron_agent  syslog forwarding feature with the syslog-release/syslog-forwarder the log message format will change. This can cause additional parsing fail, like for instance the filters from logsearch-for-cloudfoundry[3]

In this commit we add the optional property `syslog.log_template` to chose different template formats, and we provide the new 'rfc5424' format from syslog-release/syslog-forwarder, the old 'legacy` format and the format of 'metron_agent'.

For the spec property, we consider that passing a string to choose from a set of predefined log templates will allow later add additional formats like rfc5434, making it easier to transition between then. This will enable us to easily implement the solution for [4] with a smooth transition for the users of the release.

These are issues in all the related repos to start using a consistent format:

 * https://github.com/cloudfoundry/syslog-release/issues/3
 * https://github.com/cloudfoundry/loggregator/issues/134
 * https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/issues/204

[1] https://github.com/cloudfoundry/loggregator/blob/develop/jobs/metron_agent/templates/syslog_forwarder.conf.erb#L53
[2] https://github.com/cloudfoundry/syslog-release/blob/master/jobs/syslog_forwarder/templates/rsyslog.conf.erb#L56
[3] https://github.com/cloudfoundry-community/logsearch-for-cloudfoundry/blob/develop/src/logsearch-config/src/logstash-filters/snippets/platform.conf#L11-L16
[4] https://github.com/cloudfoundry/syslog-release/issues/3