### PR TITLE
Change forwarding format (rfc5424) + add instance metadata

### DIFF
--- a/jobs/syslog_forwarder/spec
+++ b/jobs/syslog_forwarder/spec
@@ -17,6 +17,9 @@ consumes:
     optional: true
 
 properties:
+  syslog.director:
+    description: "BOSH director name"
+
   syslog.forward_files:
     description: If enabled, use BlackBox to forward logs.
     default: false

--- a/jobs/syslog_forwarder/templates/rsyslog.conf.erb
+++ b/jobs/syslog_forwarder/templates/rsyslog.conf.erb
@@ -46,14 +46,20 @@ $ModLoad imudp
 $UDPServerAddress 127.0.0.1
 $UDPServerRun 514
 
-template(name="BoshLogTemplate" type="list") {
+# following https://tools.ietf.org/html/rfc5424#section-6
+template(name="SyslogForwarderTemplate" type="list") {
   constant(value="<")
   property(name="pri")
-  constant(value=">1")
+  constant(value=">1 ")
   property(name="timestamp" dateFormat="rfc3339")
   constant(value=" <%= spec.address %> ")
-  property(name="syslogtag")
-  constant(value=" [bosh instance=\"<%= spec.deployment %>/<%= spec.job.name %>/<%= spec.id %>\"] ")
+  property(name="app-name")
+  constant(value=" ")
+  property(name="procid")
+  constant(value=" ")
+  property(name="msgid")
+  # 47450 is CFF in https://www.iana.org/assignments/enterprise-numbers/enterprise-numbers
+  constant(value=" [instance@47450 director=\"<%= p('syslog.director') %>\" deployment=\"<%= spec.deployment %>\" group=\"<%= spec.job.name %>\" az=\"<%= spec.az %>\" id=\"<%= spec.id %>\"] ")
   property(name="msg")
 }
 
@@ -77,11 +83,11 @@ $ActionSendStreamDriverPermittedPeer <%= p('syslog.permitted_peer') %>
 
 <% if syslog_transport == 'relp' %>
 $ModLoad omrelp
-*.* :omrelp:<%= syslog_address %>:<%= syslog_port %>;BoshLogTemplate
+*.* :omrelp:<%= syslog_address %>:<%= syslog_port %>;SyslogForwarderTemplate
 <% elsif syslog_transport == 'udp' %>
-*.* @<%= syslog_address %>:<%= syslog_port %>;BoshLogTemplate
+*.* @<%= syslog_address %>:<%= syslog_port %>;SyslogForwarderTemplate
 <% elsif syslog_transport == 'tcp' %>
-*.* @@<%= syslog_address %>:<%= syslog_port %>;BoshLogTemplate
+*.* @@<%= syslog_address %>:<%= syslog_port %>;SyslogForwarderTemplate
 <% else %>
 <% raise "only RELP, UDP, and TCP protocols are supported (was '#{syslog_transport}')" %>
 <% end %>
@@ -96,9 +102,9 @@ $ActionExecOnlyWhenPreviousIsSuspended on
         %>
         <% if syslog_fallback_transport == 'relp' %>
 $ModLoad omrelp
-:omrelp:<%= syslog_fallback_address %>:<%= syslog_fallback_port %>;BoshLogTemplate
+:omrelp:<%= syslog_fallback_address %>:<%= syslog_fallback_port %>;SyslogForwarderTemplate
         <% elsif syslog_fallback_transport == 'tcp' %>
-& @@<%= syslog_fallback_address %>:<%= syslog_fallback_port %>;BoshLogTemplate
+& @@<%= syslog_fallback_address %>:<%= syslog_fallback_port %>;SyslogForwarderTemplate
         <% else %>
           <% raise "only RELP, and TCP protocols are supported for fallback servers (was '#{syslog_fallback_transport}')" %>
         <% end %>

--- a/jobs/syslog_storer/templates/rsyslog.conf.erb
+++ b/jobs/syslog_storer/templates/rsyslog.conf.erb
@@ -13,6 +13,11 @@ $ActionQueueHighWaterMark 8000          # Num messages. Assuming avg size of 512
 $ActionQueueTimeoutEnqueue 0            # Discard messages if the queue + disk is full
 $ActionQueueSaveOnShutdown on           # Save in-memory data to disk if rsyslog shuts down
 
+template(name="SyslogStorerTemplate" type="list") {
+  property(name="rawmsg")
+  constant(value="\n")
+}
+
 <%= p('syslog.custom_rule') %>
 
 <% if_p('syslog.port', 'syslog.transport') do |port, transport| %>
@@ -42,7 +47,7 @@ $InputTCPServerRun <%= port %>
 $ModLoad omfile
 $DirCreateMode 0700
 $FileCreateMode 0644
-*.* /var/vcap/store/syslog_storer/syslog.log
+*.* /var/vcap/store/syslog_storer/syslog.log;SyslogStorerTemplate
 
 # Prevent them from reaching anywhere else
 :programname, startswith, "vcap." ~

--- a/scripts/logstash-filters.conf
+++ b/scripts/logstash-filters.conf
@@ -1,0 +1,19 @@
+# standard rfc5424 parsing
+grok {
+  match => [ "message", "%{SYSLOG5424LINE}" ]
+}
+
+syslog_pri {}
+
+# extract BOSH instance metadata from structured data
+if [syslog5424_sd] =~ "\[instance@47450" {
+  grok {
+    match => [ "syslog5424_sd", "\[instance@47450 %{DATA:instance_raw}\]" ]
+  }
+
+  kv {
+    source => "instance_raw"
+    target => "syslog5424_sd_instance"
+    remove_field => "instance_raw"
+  }
+}


### PR DESCRIPTION
Commit messages best describe it along with the README update. Note that this significantly affects/breaks the format messages are transmitted. The change is intentional and brings it inline with existing rfc5424 standards. This does not try to influence the message format that programs log their messages in.

Example messages received from a test deployment...

    <14>1 2017-01-25T13:25:03.18377Z 192.0.2.10 etcd - - [instance@47450 director="test-env" deployment="cf" group="diego_database" az="us-west1-a" id="83bd66e5-3fdf-44b7-bdd6-508deae7c786"] [INFO] the leader is [https://diego-database-0.etcd.service.cf.internal:4001]
    <14>1 2017-01-25T13:25:03.184491Z 192.0.2.10 bbs - - [instance@47450 director="test-env" deployment="cf" group="diego_database" az="us-west1-a" id="83bd66e5-3fdf-44b7-bdd6-508deae7c786"] {"timestamp":"1485350702.539694548","source":"bbs","message":"bbs.request.start-actual-lrp.starting","log_level":1,"data":{"actual_lrp_instance_key":{"instance_guid":"271f71c7-4119-4490-619f-4f44694717c0","cell_id":"diego_cell-2-41f21178-d619-4976-901c-325bc2d0d11d"},"actual_lrp_key":{"process_guid":"1545ce89-01e6-4b8f-9cb1-5654a3ecae10-137e7eb4-12de-457d-8e3e-1258e5a74687","index":5,"domain":"cf-apps"},"method":"POST","net_info":{"address":"192.0.2.12","ports":[{"container_port":8080,"host_port":61532},{"container_port":2222,"host_port":61533}]},"request":"/v1/actual_lrps/start","session":"418.1"}}

Tested by...

 * deploying a test with forwarder + storer (there's a related commit to storer to make it log the raw messages instead of using a different format... makes it easier to review and verify the transport format)
 * deployed storer, and then forwarder as an addon to a small CF deployment
 * testing messages received by the storer against several rfc5424-compatible parsers, including logstash with an included example

Further thoughts...

 * the `syslog.director` setting could be made optional if director name were accessible by the template `spec`
 * chose to make `syslog.director`/`director` SD-ELEMENT mandatory, rather than potentially adding it further down the road and causing other breakages

This PR is a follow up to this [Google doc](https://docs.google.com/document/d/10iaWp4neGK1tIB5h5_kG7LPVVzqdQGhujaw-27TIg2g/view) where there was some discussion about it.

This fixes #3 and is related to #7.