### PR TITLE
Raise if tls_enabled is false and ca_cert provided

### DIFF
--- a/jobs/syslog_forwarder/templates/rsyslog.conf.erb
+++ b/jobs/syslog_forwarder/templates/rsyslog.conf.erb
@@ -73,7 +73,13 @@ $ActionSendStreamDriver gtls                                      # use gtls net
 $ActionSendStreamDriverMode 1                                     # require TLS
 $ActionSendStreamDriverAuthMode x509/name                         # authenticate by hostname
 $ActionSendStreamDriverPermittedPeer <%= p('syslog.permitted_peer') %>
-<% end %>
+<%
+  else
+    if_p('syslog.ca_cert') do
+      raise "A ca cert was provided but tls is not enabled. Set 'syslog.tls_enabled' to true"
+    end
+  end
+%>
 
 <% if syslog_transport == 'relp' %>
 $ModLoad omrelp


### PR DESCRIPTION
Per issue #8 I've updated the syslog forwarder job template to raise if the `tls_enabled` property is false, it's default, but a CA cert is also provided.

This should help provide faster feedback and guarantee logs are encrypted when an operator provides a cert.
```
$ bosh deploy
...
16:34:22 | Error: Unable to render instance groups for deployment. Errors are:
   - Unable to render jobs for instance group 'dummy_with_package'. Errors are:
     - Unable to render templates for job 'syslog_forwarder'. Errors are:
       - Error filling in template 'rsyslog.conf.erb' (line 79: A ca cert was provided but tls is not enabled. Set 'syslog.tls_enabled' to true)
```