### PR TITLE
Provides optional mark messages, to keep alive connection to remote server

### DIFF
--- a/jobs/syslog_forwarder/spec
+++ b/jobs/syslog_forwarder/spec
@@ -41,6 +41,13 @@ properties:
       port: 44312
       transport: tcp
 
+  syslog.enable_mark_messages:
+    description: Send mark messages; useful for keeping the connection to the server open. This option also turns log message reduction off, so duplicate messages are all sent individually; this is likely to make your logs noisier.
+    default: false
+  syslog.mark_message_period:
+    description: How often to send mark messages, in seconds. Ignored if enable_mark_messages is false.
+    default: 300
+
   syslog.custom_rule:
     description: Custom rule for syslog event forwarder.
     default: ""

--- a/jobs/syslog_forwarder/templates/rsyslog.conf.erb
+++ b/jobs/syslog_forwarder/templates/rsyslog.conf.erb
@@ -63,6 +63,15 @@ template(name="SyslogForwarderTemplate" type="list") {
   property(name="msg")
 }
 
+<% if p('syslog.enable_mark_messages') %>
+# Write mark messages to keep the connection from being idle
+global(processInternalMessages="on")
+$ActionWriteAllMarkMessages     on
+$RepeatedMsgReduction           off
+$ModLoad                        immark
+$MarkMessagePeriod              <%= p('syslog.mark_message_period') %>
+<% end %>
+
 <%= p('syslog.custom_rule') %>
 
 <% if p('syslog.tls_enabled') %>

--- a/tests/mark-messages/manifest-ops.yml
+++ b/tests/mark-messages/manifest-ops.yml
@@ -1,0 +1,12 @@
+- type: replace
+  path: /instance_groups/name=forwarder/jobs/name=syslog_forwarder/properties?/syslog/enable_mark_messages
+  value: true
+
+- type: replace
+  path: /instance_groups/name=forwarder/jobs/name=syslog_forwarder/properties?/syslog/mark_message_period
+  value: 1
+
+- type: replace
+  path: /instance_groups/name=storer/jobs/name=syslog_storer/properties?/syslog/custom_rule
+  value: "$RepeatedMsgReduction           off"
+

--- a/tests/mark-messages/test-mark-messages
+++ b/tests/mark-messages/test-mark-messages
@@ -1,0 +1,6 @@
+REM wait for mark messages
+sleep 7
+
+REM check to see that MARK messages arrived
+bosh ssh storer -c 'test $(grep MARK /var/vcap/store/syslog_storer/syslog.log | wc -l) -gt 1' \
+  || failed 'Finding mark message on syslog storer'


### PR DESCRIPTION
When logging to papertrail (and other log stash clusters), if you don't send a log message for some number of minutes, the server will close the connection. `rsyslog` doesn't notice that the connection was closed and keeps sending logs on it, until `rsyslog` is restarted. The timeout on papertrail is 15min.

Our service broker logs infrequently, so we need to turn on mark messages to ensure that the connection doesn't get closed. We imagine other services may have the same problem.