### PR TITLE
Update drain template to properly manage spaces

### DIFF
--- a/jobs/syslog_forwarder/templates/rsyslog.conf.erb
+++ b/jobs/syslog_forwarder/templates/rsyslog.conf.erb
@@ -59,7 +59,8 @@ template(name="SyslogForwarderTemplate" type="list") {
   constant(value=" ")
   property(name="msgid")
   # 47450 is CFF in https://www.iana.org/assignments/enterprise-numbers/enterprise-numbers
-  constant(value=" [instance@47450 director=\"<%= p('syslog.director') %>\" deployment=\"<%= spec.deployment %>\" group=\"<%= spec.job.name %>\" az=\"<%= spec.az %>\" id=\"<%= spec.id %>\"] ")
+  constant(value=" [instance@47450 director=\"<%= p('syslog.director') %>\" deployment=\"<%= spec.deployment %>\" group=\"<%= spec.job.name %>\" az=\"<%= spec.az %>\" id=\"<%= spec.id %>\"]")
+  property(name="msg" spifno1stsp="on" )
   property(name="msg")
 }
 


### PR DESCRIPTION
The current template will sometimes result in a a drain getting a message with an extra space as the first character.  This fix ensure an extra space doesn't get propagated to the drain.  It is the way the rsyslog drain template recommends doing it: http://www.rsyslog.com/doc/v8-stable/configuration/templates.html#standard-template-for-forwarding-to-a-remote-host-rfc3164-mode