### PR TITLE
add script to run ginkgo test

### DIFF
--- a/tests/scripts/test
+++ b/tests/scripts/test
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eux
+
+export BOSH_ENVIRONMENT=vbox
+
+pushd $(dirname $0)/../..
+  bosh create-release --force
+  bosh upload-release
+popd
+
+pushd $(dirname $0)/..
+  go get -u -a github.com/jtarchie/syslog
+  ginkgo -r -p -nodes=3 "$@"
+popd


### PR DESCRIPTION
1. `scripts/test` runs the ginkgo test from the `tests/` directory
1. It always pull down github.com/jtarchie/syslog for the latest changes, maybe we should vendor?
1. Always have a `vbox` bosh-deployment!