### PR TITLE
Allow client certs to be configurable

### DIFF
--- a/jobs/syslog_forwarder/spec
+++ b/jobs/syslog_forwarder/spec
@@ -7,6 +7,8 @@ templates:
   ca_cert.pem.erb: config/ca_cert.pem
   blackbox_ctl.erb: bin/blackbox_ctl
   blackbox_config.yml.erb: config/blackbox_config.yml
+  cert.pem.erb: config/cert.pem
+  key.pem.erb: config/key.pem
 
 packages:
   - blackbox
@@ -66,6 +68,18 @@ properties:
       -----BEGIN CERTIFICATE-----
       MIIClTCCAf4CCQDc6hJtvGB8RjANBgkqhkiG9w0BAQUFADCBjjELMAkGA1UEBhMC...
       -----END CERTIFICATE-----
+  syslog.cert:
+    description: Client Certificate if required.
+    example: |
+      -----BEGIN CERTIFICATE-----
+      MIIClTCCAf4CCQDc6hJtvGB8RjANBgkqhkiG9w0BAQUFADCBjjELMAkGA1UEBhMC...
+      -----END CERTIFICATE-----
+  syslog.key:
+    description: Client Certificate Key if required.
+    example: |
+      -----BEGIN RSA PRIVATE KEY-----
+      MIIClTCCAf4CCQDc6hJtvGB8RjANBgkqhkiG9w0BAQUFADCBjjELMAkGA1UEBhMC...
+      -----END RSA PRIVATE KEY-----
   syslog.queue_file_name:
     description: Spill to disk if queue is full.
     default: agg_backlog

--- a/jobs/syslog_forwarder/templates/cert.pem.erb
+++ b/jobs/syslog_forwarder/templates/cert.pem.erb
@@ -1,0 +1,1 @@
+<% if_p('syslog.cert') do |v| %><%= v %><% end %>

--- a/jobs/syslog_forwarder/templates/key.pem.erb
+++ b/jobs/syslog_forwarder/templates/key.pem.erb
@@ -1,0 +1,1 @@
+<% if_p('syslog.key') do |v| %><%= v %><% end %>

--- a/jobs/syslog_forwarder/templates/rsyslog.conf.erb
+++ b/jobs/syslog_forwarder/templates/rsyslog.conf.erb
@@ -69,12 +69,23 @@ template(name="SyslogForwarderTemplate" type="list") {
 <% if p('syslog.tls_enabled') %>
   <%
     ca_cert_path = '/etc/ssl/certs/ca-certificates.crt'
-
+    cert_path = nil
+    key_path = nil
     if_p('syslog.ca_cert') do
       ca_cert_path = '/var/vcap/jobs/syslog_forwarder/config/ca_cert.pem'
     end
+    if_p('syslog.cert') do
+      cert_path = '/var/vcap/jobs/syslog_forwarder/config/cert.pem'
+    end
+    if_p('syslog.key') do
+      key_path = '/var/vcap/jobs/syslog_forwarder/config/key.pem'
+    end
   %>
 
+<% if key_path && cert_path %>
+$DefaultNetstreamDriverCertFile <%= cert_path %>
+$DefaultNetstreamDriverKeyFile <%= key_path %>
+<% end %>
 $DefaultNetstreamDriverCAFile <%= ca_cert_path %>                 # trust these CAs
 $ActionSendStreamDriver gtls                                      # use gtls netstream driver
 $ActionSendStreamDriverMode 1                                     # require TLS


### PR DESCRIPTION
Our syslog endpoint requires a client cert. This PR adds optional client cert/key properties.