### PR TITLE
Add syslog_forwarder_windows job

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,5 +1,7 @@
----
 golang/go1.7.3.linux-amd64.tar.gz:
+  size: 82565628
   object_id: e8c976ee-6efc-4901-80d6-1bfd7ba7b476
   sha: ead40e884ad4d6512bcf7b3c7420dd7fa4a96140
-  size: 82565628
+golang/go1.7.3.windows-amd64.zip:
+  size: 88850225
+  sha: d10f32a97baa97344af80b6fa61374debe12124f

--- a/jobs/syslog_forwarder_windows/monit
+++ b/jobs/syslog_forwarder_windows/monit
@@ -1,0 +1,15 @@
+{
+  "processes": [
+    {
+      "name": "syslog_forwarder_windows",
+      "executable": "C:\\var\\vcap\\packages\\blackbox-windows\\blackbox.exe",
+      "args": ["-config", "c:\\var\\vcap\\jobs\\syslog_forwarder_windows\\config\\blackbox_config.yml"],
+      "env": {
+        <% if p('syslog.blackbox.limit_cpu') %>
+          "GOMAXPROCS": "1"
+        <% end %>
+      }
+    }
+  ]
+}
+

--- a/jobs/syslog_forwarder_windows/spec
+++ b/jobs/syslog_forwarder_windows/spec
@@ -1,0 +1,40 @@
+---
+name: syslog_forwarder_windows
+
+templates:
+  blackbox_config.yml.erb: config/blackbox_config.yml
+
+packages:
+  - blackbox-windows
+
+properties:
+  syslog.transport:
+    description: >
+      Protocol that Blackbox will use when forwarding loglines from files
+      to the remote address.
+      Using TCP will prevent truncation of log lines over 1KB,
+      but may have undesirable performance impact.
+    default: tcp
+    description: One of `udp`, `tcp`
+  syslog.address:
+    description: IP or DNS address of the syslog server.
+    example: logs4.papertrail.com
+  syslog.port:
+    description: Port of the syslog server.
+    default: 514
+
+  syslog.blackbox.hostname:
+    description: >
+      The hostname that will appear in the syslog messages.
+      By default, blackbox will detect hostname.
+    default: ""
+
+  syslog.blackbox.source_dir:
+    description: >
+      directory with subdirectories containing log files.
+      log lines will be tagged with subdirectory name.
+    default: "c:\\var\\vcap\\sys\\log"
+
+  syslog.blackbox.limit_cpu:
+    description: limit goprocess to a single cpu via gomaxprocs
+    default: true

--- a/jobs/syslog_forwarder_windows/templates/blackbox_config.yml.erb
+++ b/jobs/syslog_forwarder_windows/templates/blackbox_config.yml.erb
@@ -1,0 +1,8 @@
+hostname: <%= p('syslog.blackbox.hostname') %>
+
+syslog:
+  destination:
+    transport: <%= p('syslog.transport') %>
+    address:  <%= p('syslog.address') %>:<%= p('syslog.port') %>
+
+  source_dir: <%= p("syslog.blackbox.source_dir") %>

--- a/packages/blackbox-windows/packaging
+++ b/packages/blackbox-windows/packaging
@@ -1,0 +1,24 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+$BOSH_INSTALL_TARGET = Resolve-Path "${env:BOSH_INSTALL_TARGET}"
+
+$env:GOROOT="C:\var\vcap\packages\golang-windows\go"
+$env:GOPATH="${BOSH_INSTALL_TARGET}"
+$env:PATH="${env:GOROOT}\bin;${env:PATH}"
+$pkg_name="blackbox"
+$pkg_path="github.com/concourse/blackbox/cmd/blackbox"
+
+New-Item -ItemType "directory" -Force "${BOSH_INSTALL_TARGET}\src"
+
+robocopy.exe /E "${PWD}" "${BOSH_INSTALL_TARGET}\src"
+if ($LASTEXITCODE -ge 8) {
+    Write-Error "robocopy.exe /E ${PWD} ${BOSH_INSTALL_TARGET}\src"
+}
+
+go.exe build -o "${BOSH_INSTALL_TARGET}\${pkg_name}.exe" "${pkg_path}"
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Error compiling: ${pkg_path}"
+}
+
+Remove-Item -Recurse -Path "${BOSH_INSTALL_TARGET}\src" -Force

--- a/packages/blackbox-windows/spec
+++ b/packages/blackbox-windows/spec
@@ -1,0 +1,10 @@
+---
+name: blackbox-windows
+dependencies:
+  - golang-windows
+files:
+  - github.com/concourse/blackbox/**/*.go
+  - github.com/hpcloud/tail/**/*.go
+  - github.com/papertrail/remote_syslog2/syslog/**/*.go
+  - github.com/tedsuo/ifrit/**/*.go
+  - gopkg.in/yaml.v2/**/*.go

--- a/packages/golang-windows/packaging
+++ b/packages/golang-windows/packaging
@@ -1,0 +1,8 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+$BOSH_INSTALL_TARGET = Resolve-Path $env:BOSH_INSTALL_TARGET
+
+$path=(Get-ChildItem "golang/go*.windows-amd64.zip").FullName
+
+Expand-Archive -Path $path -DestinationPath ${BOSH_INSTALL_TARGET} -Force

--- a/packages/golang-windows/spec
+++ b/packages/golang-windows/spec
@@ -1,0 +1,7 @@
+---
+name: golang-windows
+
+dependencies: []
+
+files:
+- golang/go*.windows-amd64.zip


### PR DESCRIPTION
This PR adds a syslog_forwarder_windows job which uses blackbox to forward BOSH logs directly to a syslog endpoint.

Since rsyslogd does not exist on Windows, the options relevant to configuring rsyslogd on Linux have been removed from the Windows job spec.

To the blackbox config, we added the ability to set the hostname (missing in linux).

For our version of golang, we PR'd 1.7.3 to match the Linux version. We couldn't upload the blob (so it's just local right now), but the golang we used can be downloaded here: https://dl.google.com/go/go1.7.3.windows-amd64.zip
