### PR TITLE
Introduce property to log filename with blackbox

### DIFF
--- a/jobs/syslog_forwarder/spec
+++ b/jobs/syslog_forwarder/spec
@@ -133,6 +133,10 @@ properties:
       log lines will be tagged with subdirectory name.
     default: /var/vcap/sys/log
 
+  syslog.blackbox.log_filename:
+    description: If set to true, log lines are also tagged with filename in the format <subdirectory>/<file.log>.
+    default: false
+
   syslog.blackbox.limit_cpu:
     description: limit goprocess to a single cpu via gomaxprocs
     default: true

--- a/jobs/syslog_forwarder/templates/blackbox_config.yml.erb
+++ b/jobs/syslog_forwarder/templates/blackbox_config.yml.erb
@@ -10,3 +10,4 @@ syslog:
     address: 127.0.0.1:514
 
   source_dir: <%= p("syslog.blackbox.source_dir") %>
+  log_filename: <%= p("syslog.blackbox.log_filename") %>


### PR DESCRIPTION
Follow-up to this issue: https://github.com/cloudfoundry/blackbox/issues/5#issuecomment-405417287

This PR will not change the default behaviour. Only if `syslog.blackbox.log_filename` is set to `true` "subdirectories"/"logfilename" will be logged by blackbox as `app-name`.

Open question: @anEXPer Do you think it is fine to bump blackbox to master for this PR?