### PR TITLE
[issue 76] Certificates for mTLS configuration

### DIFF
--- a/jobs/syslog_forwarder/spec
+++ b/jobs/syslog_forwarder/spec
@@ -5,6 +5,9 @@ templates:
   blackbox_ctl.erb: bin/blackbox_ctl
   blackbox_config.yml.erb: config/blackbox_config.yml
   ca_cert.pem.erb: config/ca_cert.pem
+  mtls_ca_cert.pem.erb: config/mtls_ca_cert.pem
+  mtls_client_cert.pem.erb: config/mtls_client_cert.pem
+  mtls_client_key.pem.erb: config/mtls_client_key.pem
   drain.erb: bin/drain
   pre-start.erb: bin/pre-start
   syslog-release.conf.erb: config/syslog-release.conf
@@ -120,6 +123,12 @@ properties:
       -----BEGIN CERTIFICATE-----
       MIIClTCCAf4CCQDc6hJtvGB8RjANBgkqhkiG9w0BAQUFADCBjjELMAkGA1UEBhMC...
       -----END CERTIFICATE-----
+  syslog.mtls_ca_cert:
+    description: Trusted CA for syslog forwarding over mTLS
+  syslog.mtls_client_cert:
+    description: Client certificate for syslog forwarding over mTLS
+  syslog.mtls_client_key:
+    description: Client key for syslog forwarding over mTLS
   syslog.queue_file_name:
     description: Spill to disk if queue is full.
     default: agg_backlog

--- a/jobs/syslog_forwarder/templates/mtls_ca_cert.pem.erb
+++ b/jobs/syslog_forwarder/templates/mtls_ca_cert.pem.erb
@@ -1,0 +1,1 @@
+<% if_p('syslog.mtls_ca_cert') do |v| %><%= v %><% end %>

--- a/jobs/syslog_forwarder/templates/mtls_client_cert.pem.erb
+++ b/jobs/syslog_forwarder/templates/mtls_client_cert.pem.erb
@@ -1,0 +1,1 @@
+<% if_p('syslog.mtls_client_cert') do |v| %><%= v %><% end %>

--- a/jobs/syslog_forwarder/templates/mtls_client_key.pem.erb
+++ b/jobs/syslog_forwarder/templates/mtls_client_key.pem.erb
@@ -1,0 +1,1 @@
+<% if_p('syslog.mtls_client_key') do |v| %><%= v %><% end %>

--- a/jobs/syslog_forwarder/templates/pre-start.erb
+++ b/jobs/syslog_forwarder/templates/pre-start.erb
@@ -12,6 +12,16 @@ chown -R syslog:adm /var/vcap/data/syslog_forwarder/buffered
 
 mkdir -p /etc/rsyslog.d
 
+<% if_p('syslog.mtls_ca_cert') do %>
+  cp $(dirname $0)/../config/mtls_ca_cert.pem /etc/rsyslog.d/server-ca.crt
+<% end %>
+<% if_p('syslog.mtls_client_cert') do %>
+  cp $(dirname $0)/../config/mtls_client_cert.pem /etc/rsyslog.d/client.crt
+<% end %>
+<% if_p('syslog.mtls_client_key') do %>
+  cp $(dirname $0)/../config/mtls_client_key.pem /etc/rsyslog.d/client.key
+<% end %>
+
 # This cleans up after legacy config locations and previous starts
 rm -f /etc/rsyslog.d/rsyslog.conf /etc/rsyslog.d/*-syslog-release*conf
 


### PR DESCRIPTION
* new parameters to specify CA, client certificate and client key for a mTLS setup
* don't change existing "tls_enabled" and "ca_cert" parameters to allow mixed setups (multiple syslog forwarding rules without TLS / with TLS / with mTLS)

# Description

Introduce new parameters to handle mTLS certificates (CA, client certificate and client key).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [ ] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

