### PR TITLE
Publish 11.x releases on main branch

### DIFF
--- a/releases/syslog/index.yml
+++ b/releases/syslog/index.yml
@@ -33,6 +33,8 @@ builds:
     version: 11.3.2
   59dd35e4-84dc-44bc-6427-6bd88db8bcee:
     version: 11.7.4
+  5a12549d-65b1-4f0c-63bc-f60a9e2f2e1e:
+    version: 11.8.1
   5ead852e-16b5-4da8-4648-706f9d3b802e:
     version: 11.7.1
   60a1d334-d55a-42f0-49f9-66dc8e69ff6f:

--- a/releases/syslog/index.yml
+++ b/releases/syslog/index.yml
@@ -73,6 +73,8 @@ builds:
     version: "1"
   be7a6ed8-4c42-46b4-b240-6ac7eb929158:
     version: "4"
+  bf81896c-69bf-41e9-5429-ce48880bf127:
+    version: 11.8.3
   c1760d0d-b048-4b4e-6d6f-6f41bb21a43c:
     version: 12.0.1
   cfeb80b4-8201-4b78-5665-a70c88bdc7f0:

--- a/releases/syslog/index.yml
+++ b/releases/syslog/index.yml
@@ -59,6 +59,8 @@ builds:
     version: 11.7.2
   86b1cb85-4902-4db5-4ab9-57ed222ad504:
     version: 11.6.0
+  8c3a3eef-042a-4227-75d9-0e1f8891c12d:
+    version: 11.8.4
   8c570810-182f-405b-4f1b-4ac5346963c2:
     version: 11.7.7
   977ec5f5-d1aa-4425-5b11-721ad35cb75e:

--- a/releases/syslog/index.yml
+++ b/releases/syslog/index.yml
@@ -1,4 +1,6 @@
 builds:
+  1332df41-edb9-4654-4b56-16e21dd772a2:
+    version: 11.8.2
   14cd303c-a773-4c4a-7b83-2fdc539601c4:
     version: 11.6.1
   168598c5-4f3e-41e1-4625-3ff1c87afc5f:

--- a/releases/syslog/index.yml
+++ b/releases/syslog/index.yml
@@ -15,6 +15,8 @@ builds:
     version: 11.7.11
   37f2b194-5fd8-4694-7a8b-4301d0b1e2d6:
     version: 11.3.1
+  3a42d829-7533-4f76-6c08-d4b3532cd4f1:
+    version: 11.8.5
   3e9c09f2-5849-4707-5f18-cfe4ba31a98b:
     version: 11.0.2
   42affbae-7c8e-4cdc-5a0e-509b0ce4d60a:

--- a/releases/syslog/syslog-11.8.1.yml
+++ b/releases/syslog/syslog-11.8.1.yml
@@ -1,0 +1,32 @@
+name: syslog
+version: 11.8.1
+commit_hash: fd1b95d
+uncommitted_changes: false
+jobs:
+- name: syslog_forwarder
+  version: 611534c8c45e48a4d051512bfa79f72e5c292a9ac011e95255d8ed01d51aa3de
+  fingerprint: 611534c8c45e48a4d051512bfa79f72e5c292a9ac011e95255d8ed01d51aa3de
+  sha1: sha256:d55e01897ffdf66658036b8f1f905edf536d1cbc8ab481e4fca0b6fd8e08f66f
+  packages:
+  - blackbox
+- name: syslog_storer
+  version: f3428e9ec66e9657a08f0c18606100c9a4a78c63a66ca03dda5ba59735f85878
+  fingerprint: f3428e9ec66e9657a08f0c18606100c9a4a78c63a66ca03dda5ba59735f85878
+  sha1: sha256:7d7e862af0c3aeb2cccb4fe68c268722763b39b1f9cebdeff59db70a3fca07a7
+  packages: []
+packages:
+- name: blackbox
+  version: fe4e6b7af67dd001db04a98735df7b409da0530290aa6006c54d105e56d1f979
+  fingerprint: fe4e6b7af67dd001db04a98735df7b409da0530290aa6006c54d105e56d1f979
+  sha1: sha256:dfb22907443b12055d255939d9194fea98461b8e4f2246d339035c6ad92fff25
+  dependencies:
+  - golang-1-linux
+- name: golang-1-linux
+  version: 4c3c9f041ae80eb4373ed31efe56164d0f4733456c3e110d62dd92d310d6b86e
+  fingerprint: 4c3c9f041ae80eb4373ed31efe56164d0f4733456c3e110d62dd92d310d6b86e
+  sha1: sha256:7f7b3d644983a5fadc45b38c6f1112bb469d93b2960d697e9dcffdebc5a6fceb
+  dependencies: []
+license:
+  version: 8e4174f96e7d8edb37c82965f0c61222e80a5ea2992f55f1e7cc7f4ef800600c
+  fingerprint: 8e4174f96e7d8edb37c82965f0c61222e80a5ea2992f55f1e7cc7f4ef800600c
+  sha1: sha256:b39221693df0d2ca912c343570485ae27070755899ced4c7cca183f42d454299

--- a/releases/syslog/syslog-11.8.2.yml
+++ b/releases/syslog/syslog-11.8.2.yml
@@ -1,0 +1,32 @@
+name: syslog
+version: 11.8.2
+commit_hash: feb13df
+uncommitted_changes: false
+jobs:
+- name: syslog_forwarder
+  version: 611534c8c45e48a4d051512bfa79f72e5c292a9ac011e95255d8ed01d51aa3de
+  fingerprint: 611534c8c45e48a4d051512bfa79f72e5c292a9ac011e95255d8ed01d51aa3de
+  sha1: sha256:d55e01897ffdf66658036b8f1f905edf536d1cbc8ab481e4fca0b6fd8e08f66f
+  packages:
+  - blackbox
+- name: syslog_storer
+  version: f3428e9ec66e9657a08f0c18606100c9a4a78c63a66ca03dda5ba59735f85878
+  fingerprint: f3428e9ec66e9657a08f0c18606100c9a4a78c63a66ca03dda5ba59735f85878
+  sha1: sha256:7d7e862af0c3aeb2cccb4fe68c268722763b39b1f9cebdeff59db70a3fca07a7
+  packages: []
+packages:
+- name: blackbox
+  version: f90a8f7836840033b7b2fdd94c6cce7da51b534da4b694bc34fc338df4b9f58e
+  fingerprint: f90a8f7836840033b7b2fdd94c6cce7da51b534da4b694bc34fc338df4b9f58e
+  sha1: sha256:83792875db720c6a9ae683fc936db2f99525e10d21e1e3a8d97387567f45343b
+  dependencies:
+  - golang-1-linux
+- name: golang-1-linux
+  version: a54b33c812a8cfc39ba82782a23d74bf33f5a0a92012b41a101cc9d9d48d345c
+  fingerprint: a54b33c812a8cfc39ba82782a23d74bf33f5a0a92012b41a101cc9d9d48d345c
+  sha1: sha256:089e88df2a4d69243a14a1adeeb5011deaaf602dedb55d476a83d45f1c03fdc9
+  dependencies: []
+license:
+  version: 8e4174f96e7d8edb37c82965f0c61222e80a5ea2992f55f1e7cc7f4ef800600c
+  fingerprint: 8e4174f96e7d8edb37c82965f0c61222e80a5ea2992f55f1e7cc7f4ef800600c
+  sha1: sha256:b39221693df0d2ca912c343570485ae27070755899ced4c7cca183f42d454299

--- a/releases/syslog/syslog-11.8.3.yml
+++ b/releases/syslog/syslog-11.8.3.yml
@@ -1,0 +1,32 @@
+name: syslog
+version: 11.8.3
+commit_hash: fbddfee
+uncommitted_changes: false
+jobs:
+- name: syslog_forwarder
+  version: 611534c8c45e48a4d051512bfa79f72e5c292a9ac011e95255d8ed01d51aa3de
+  fingerprint: 611534c8c45e48a4d051512bfa79f72e5c292a9ac011e95255d8ed01d51aa3de
+  sha1: sha256:d55e01897ffdf66658036b8f1f905edf536d1cbc8ab481e4fca0b6fd8e08f66f
+  packages:
+  - blackbox
+- name: syslog_storer
+  version: f3428e9ec66e9657a08f0c18606100c9a4a78c63a66ca03dda5ba59735f85878
+  fingerprint: f3428e9ec66e9657a08f0c18606100c9a4a78c63a66ca03dda5ba59735f85878
+  sha1: sha256:7d7e862af0c3aeb2cccb4fe68c268722763b39b1f9cebdeff59db70a3fca07a7
+  packages: []
+packages:
+- name: blackbox
+  version: b362a9543641c30e8c41dc752a120d6792c2860c10047a4a1154d7caa1f99036
+  fingerprint: b362a9543641c30e8c41dc752a120d6792c2860c10047a4a1154d7caa1f99036
+  sha1: sha256:86399e485eca5bf109c4ae9fd1b057bb216e7e4c5c2564b99f67e0b4a7b42217
+  dependencies:
+  - golang-1.18-linux
+- name: golang-1.18-linux
+  version: 1b9cab9fe43325f2ca9b4c2cabe29313e49246e82542c9cbfc7b60b5ae807d80
+  fingerprint: 1b9cab9fe43325f2ca9b4c2cabe29313e49246e82542c9cbfc7b60b5ae807d80
+  sha1: sha256:f11a91516d479600974c5d3af7d68b1dc0bb0e6a97578e6fbc3fde9ec26fa428
+  dependencies: []
+license:
+  version: 8e4174f96e7d8edb37c82965f0c61222e80a5ea2992f55f1e7cc7f4ef800600c
+  fingerprint: 8e4174f96e7d8edb37c82965f0c61222e80a5ea2992f55f1e7cc7f4ef800600c
+  sha1: sha256:b39221693df0d2ca912c343570485ae27070755899ced4c7cca183f42d454299

--- a/releases/syslog/syslog-11.8.4.yml
+++ b/releases/syslog/syslog-11.8.4.yml
@@ -1,0 +1,32 @@
+name: syslog
+version: 11.8.4
+commit_hash: 1a07df5
+uncommitted_changes: false
+jobs:
+- name: syslog_forwarder
+  version: 611534c8c45e48a4d051512bfa79f72e5c292a9ac011e95255d8ed01d51aa3de
+  fingerprint: 611534c8c45e48a4d051512bfa79f72e5c292a9ac011e95255d8ed01d51aa3de
+  sha1: sha256:d55e01897ffdf66658036b8f1f905edf536d1cbc8ab481e4fca0b6fd8e08f66f
+  packages:
+  - blackbox
+- name: syslog_storer
+  version: f3428e9ec66e9657a08f0c18606100c9a4a78c63a66ca03dda5ba59735f85878
+  fingerprint: f3428e9ec66e9657a08f0c18606100c9a4a78c63a66ca03dda5ba59735f85878
+  sha1: sha256:7d7e862af0c3aeb2cccb4fe68c268722763b39b1f9cebdeff59db70a3fca07a7
+  packages: []
+packages:
+- name: blackbox
+  version: 9745e9f715ac8729e393e753d00ec907a401cc80357b2ad4e2d338ee535fc49f
+  fingerprint: 9745e9f715ac8729e393e753d00ec907a401cc80357b2ad4e2d338ee535fc49f
+  sha1: sha256:cd2fd9a0dbfe5a45fa41007ee67541df682fe0ca3f9fc9ccb40c28ddfa9a82fb
+  dependencies:
+  - golang-1.19-linux
+- name: golang-1.19-linux
+  version: 491d1f5cd707031551fbc81626dcc00a34a474c49e6135f920e8e50364148112
+  fingerprint: 491d1f5cd707031551fbc81626dcc00a34a474c49e6135f920e8e50364148112
+  sha1: sha256:866e779bb9d4c5a2c538d7d021831d15778994c4a13b8051d58fc9099fa36dae
+  dependencies: []
+license:
+  version: 8e4174f96e7d8edb37c82965f0c61222e80a5ea2992f55f1e7cc7f4ef800600c
+  fingerprint: 8e4174f96e7d8edb37c82965f0c61222e80a5ea2992f55f1e7cc7f4ef800600c
+  sha1: sha256:b39221693df0d2ca912c343570485ae27070755899ced4c7cca183f42d454299

--- a/releases/syslog/syslog-11.8.5.yml
+++ b/releases/syslog/syslog-11.8.5.yml
@@ -1,0 +1,32 @@
+name: syslog
+version: 11.8.5
+commit_hash: 534a373
+uncommitted_changes: false
+jobs:
+- name: syslog_forwarder
+  version: 611534c8c45e48a4d051512bfa79f72e5c292a9ac011e95255d8ed01d51aa3de
+  fingerprint: 611534c8c45e48a4d051512bfa79f72e5c292a9ac011e95255d8ed01d51aa3de
+  sha1: sha256:d55e01897ffdf66658036b8f1f905edf536d1cbc8ab481e4fca0b6fd8e08f66f
+  packages:
+  - blackbox
+- name: syslog_storer
+  version: f3428e9ec66e9657a08f0c18606100c9a4a78c63a66ca03dda5ba59735f85878
+  fingerprint: f3428e9ec66e9657a08f0c18606100c9a4a78c63a66ca03dda5ba59735f85878
+  sha1: sha256:7d7e862af0c3aeb2cccb4fe68c268722763b39b1f9cebdeff59db70a3fca07a7
+  packages: []
+packages:
+- name: blackbox
+  version: 1fc7e011d956699ac37ca5f00e7941e037136d159d179a41fdf50cc1675d19c4
+  fingerprint: 1fc7e011d956699ac37ca5f00e7941e037136d159d179a41fdf50cc1675d19c4
+  sha1: sha256:fa093c249795c72ccdc7e33f1c0482c190df805daa9ba46f00e002226d3a4095
+  dependencies:
+  - golang-1.19-linux
+- name: golang-1.19-linux
+  version: 3b157e9d492246f0a43d3a68327117efe1465b2883a1f1cc86bc76c0d85cf806
+  fingerprint: 3b157e9d492246f0a43d3a68327117efe1465b2883a1f1cc86bc76c0d85cf806
+  sha1: sha256:8ef5fdee43875176238fb42017aace683c16108adb2c5e33cc97403fdf16d7fc
+  dependencies: []
+license:
+  version: 8e4174f96e7d8edb37c82965f0c61222e80a5ea2992f55f1e7cc7f4ef800600c
+  fingerprint: 8e4174f96e7d8edb37c82965f0c61222e80a5ea2992f55f1e7cc7f4ef800600c
+  sha1: sha256:b39221693df0d2ca912c343570485ae27070755899ced4c7cca183f42d454299


### PR DESCRIPTION
# Description

Recent 11.x releases are [not currently available on bosh.io](https://bosh.io/releases/github.com/cloudfoundry/syslog-release?all=1) due to not existing on the `main` branch.

Manually bring them across for now. Automating is tricky because of likely conflicts.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
