### PR TITLE
Use GinkgoParallelProcess() over GinkgoParallelNode() in tests

### DIFF
--- a/tests/boshhelpers_test.go
+++ b/tests/boshhelpers_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func DeploymentName() string {
-	return fmt.Sprintf("syslog-tests-%d", GinkgoParallelNode())
+	return fmt.Sprintf("syslog-tests-%d", GinkgoParallelProcess())
 }
 
 func StemcellOS() string {


### PR DESCRIPTION
# Description

`GinkgoParallelNode()` is deprecated and could be removed at any time.

## Type of change

- [x] Test change

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
