### PR TITLE
Fix: Remove unnecessary tools.go

### DIFF
--- a/tests/tools.go
+++ b/tests/tools.go
@@ -1,8 +1,0 @@
-//go:build tools
-// +build tools
-
-package tools
-
-import (
-	_ "github.com/onsi/ginkgo/v2/ginkgo"
-)


### PR DESCRIPTION
# Description

As of v2.8.2, Ginkgo "now includes a tools.go file in the root directory of the ginkgo package. This should allow modules that simply go get github.com/onsi/ginkgo/v2 to also pull in the CLI dependencies. This obviates the need for consumers of Ginkgo to have their own tools.go file and makes it simpler to ensure that the version of the ginkgo CLI being used matches the version of the library."

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
