### PR TITLE
Add environment structured data parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,14 +224,8 @@ will need to [install Go][go-installation].
 Note that the `go.mod` and `go.sum` files in this repo are only for the test
 code.
 
-Before running tests, you'll need to create a bosh director. First, ensure the
-bosh cli is installed and the bosh-deployment repository is downloaded and
-located at `~/workspace/bosh-deployment`. You can then run
-`./scripts/setup-bosh-lite-for-tests.sh` to create the director. Afterwards
-execute `source export-bosh-lite-creds.sh` to target the bosh director.
-
-(Alternatively, if you wish to run the specs against the CI env, you can
-`source` the `.envrc` in your env-repo.)
+The tests expect that your local environment has the BOSH CLI installed and
+configured correctly to point to a BOSH Director.
 
 The tests can then be run from the top of the repo with `./scripts/test`.
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ contains the following fields:
 * instance group
 * instance ID
 
+The structured data may also contain an optional `environment` field if
+provided by the operator.
+
 The whole thing looks something like this:
 
 ```

--- a/jobs/syslog_forwarder/spec
+++ b/jobs/syslog_forwarder/spec
@@ -29,7 +29,9 @@ properties:
   syslog.director:
     description: "BOSH Director name"
     default: ""
-
+  syslog.environment:
+    description: "Optional environment identifier"
+    default: ""
   syslog.forward_files:
     description: If enabled, use BlackBox to forward logs.
     default: true

--- a/jobs/syslog_forwarder/templates/syslog-release-forwarding-setup.conf.erb
+++ b/jobs/syslog_forwarder/templates/syslog-release-forwarding-setup.conf.erb
@@ -18,6 +18,9 @@ end
 
 %>
 set $.director = "<%= p('syslog.director') %>";
+<% if p('syslog.environment') != '' -%>
+set $.environment = "<%= p('syslog.environment') %>";
+<% end -%>
 set $.deployment = "<%= spec.deployment %>";
 set $.instance = "<%= spec.name %>";
 set $.az = "<%= spec.az %>";
@@ -37,6 +40,10 @@ template(name="SyslogForwarderTemplate" type="list") {
   # 47450 is CFF in https://www.iana.org/assignments/enterprise-numbers/enterprise-numbers
   constant(value=" [instance@47450 director=\"")
   property(name="$.director")
+<% if p('syslog.environment') != '' -%>
+  constant(value="\" environment=\"")
+  property(name="$.environment")
+<% end -%>
   constant(value="\" deployment=\"")
   property(name="$.deployment")
   constant(value="\" group=\"")

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,24 +3,12 @@
 ## Development
 
 The following commands assume you are operating
-from the top level of the repo, have go inistalled,
+from the top level of the repo, have go installed,
 and have initialized and updated the blackbox submodule
 as described in the main [README](../README.md).
 
-First, you'll need to setup a bosh-lite and login to it.
-If you don't have a bosh-lite running
-and aliased as `vbox` already:
-
-```sh
-scripts/setup-bosh-lite-for-tests.sh
-```
-
-If you don't already have BOSH credential
-environment variables in your session:
-
-```sh
-source scripts/export-bosh-lite-creds.sh
-```
+Ensure that you have a BOSH Director deployed and your local environment is
+configured to point to the BOSH Director.
 
 To then run the tests locally:
 

--- a/tests/manifests/environment-identifier.yml
+++ b/tests/manifests/environment-identifier.yml
@@ -1,0 +1,40 @@
+---
+name: ((deployment))
+releases:
+  - name: syslog
+    version: latest
+stemcells:
+  - alias: default
+    os: ((stemcell-os))
+    version: latest
+instance_groups:
+  - name: forwarder
+    instances: 1
+    vm_type: default
+    stemcell: default
+    networks:
+      - name: default
+    azs:
+      - z1
+    jobs:
+      - name: syslog_forwarder
+        release: syslog
+    properties:
+      syslog:
+        environment: "some-environment-identifier"
+  - name: storer
+    instances: 1
+    vm_type: default
+    stemcell: default
+    networks:
+      - name: default
+    azs:
+      - z1
+    jobs:
+      - name: syslog_storer
+        release: syslog
+update:
+  canaries: 1
+  max_in_flight: 1
+  canary_watch_time: 1000-60000
+  update_watch_time: 1000-60000


### PR DESCRIPTION
# Description

- Operators are already able to tag emitted log lines with the BOSH Director name with the `director` structured data parameter.
- Add a new `environment` structured data parameter for cases where log lines should be tagged with an operator provided string but need to vary from the director name.
- Don't add the environment SD-PARAM when the BOSH property is not provided by the operator. This prevents any log parsing breakage that might occur if log processors were to be string matching rather than parsing syslog messages correctly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update (included in this PR)

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [X] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [X] I have made corresponding changes to the documentation
- [X] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
