### PR TITLE
pre-start: Use Service to restart rsyslog

### DIFF
--- a/jobs/syslog_forwarder/templates/pre-start.erb
+++ b/jobs/syslog_forwarder/templates/pre-start.erb
@@ -43,4 +43,4 @@ chmod 0644 /etc/rsyslog.d/40-syslog-release-file-exclusion.conf
 
 <% end %>
 
-systemctl restart rsyslog
+service rsyslog restart


### PR DESCRIPTION
- bosh-lites do not use systemd as the init system
- restarting rsyslog using service fixes the issue
- service defers to systemctl on ubuntu noble so the behavior remains unchanged on ubuntu noble stemcells

Ran the acceptance tests on bosh-lites and a full bosh environment and saw them go green. 
Not sure if these changes are worth documenting in any way

[slack context](https://vmware.slack.com/archives/C05JHSGA5PG/p1717021141092499)

[#187667831](https://www.pivotaltracker.com/story/show/187667831)

Authored-by: Kyle Ong <kyleo@vmware.com>

# Description

Please include a summary of the change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [x] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
