### PR TITLE
chore: Bump to Go1.22

### DIFF
--- a/packages/blackbox/packaging
+++ b/packages/blackbox/packaging
@@ -1,5 +1,5 @@
 set -e
-source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.22-linux/bosh/compile.env
 export GO111MODULE=auto
 
 cd blackbox/cmd/blackbox

--- a/packages/blackbox/spec
+++ b/packages/blackbox/spec
@@ -1,7 +1,7 @@
 ---
 name: blackbox
 dependencies:
-- golang-1.21-linux
+- golang-1.22-linux
 files:
 - blackbox/**/*
 excluded_files:

--- a/packages/golang-1.21-linux/spec.lock
+++ b/packages/golang-1.21-linux/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1.21-linux
-fingerprint: 55147e471cfe150f63898ed1ae13b6cb48dac8f198d415319b14572ea7a55443

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module syslog_integration_tests
 
-go 1.21
+go 1.22
 
 require (
 	github.com/jtarchie/syslog v0.0.0-20200616043123-c6861be235b9


### PR DESCRIPTION
# Description

- Removes go1.21 packages
- Uses go1.22 packages to build the other packages

## Type of change

- [x] Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
