### PR TITLE
add apparmor write permissiosn for syslog location.

### DIFF
--- a/jobs/syslog_storer/spec
+++ b/jobs/syslog_storer/spec
@@ -8,6 +8,7 @@ templates:
   ca.pem.erb: config/ca.pem
   syslog-storer.key.erb: config/syslog-storer.key
   syslog-storer.crt.erb: config/syslog-storer.crt
+  syslog.apparmor.erb: config/syslog.apparmor
 
 provides:
 - name: syslog_storer

--- a/jobs/syslog_storer/templates/pre-start.erb
+++ b/jobs/syslog_storer/templates/pre-start.erb
@@ -8,4 +8,7 @@ chown -R syslog:adm /var/vcap/store/syslog_storer
 
 mkdir -p /etc/rsyslog.d
 cp $(dirname $0)/../config/rsyslog.conf /etc/rsyslog.d/rsyslog.conf
+if [ -d "/etc/apparmor.d/rsyslog.d/" ]; then
+  cp $(dirname $0)/../config/syslog.apparmor /etc/apparmor.d/rsyslog.d/syslog.apparmor
+fi
 service rsyslog restart

--- a/jobs/syslog_storer/templates/syslog.apparmor.erb
+++ b/jobs/syslog_storer/templates/syslog.apparmor.erb
@@ -1,3 +1,3 @@
 # syslog_storer rules
-    /var/vcap/store/syslog_storer/ rwl,
-    /var/vcap/store/syslog_storer/** rwk,
+    /var/vcap/store/syslog_storer/ rw,
+    /var/vcap/store/syslog_storer/** rw,

--- a/jobs/syslog_storer/templates/syslog.apparmor.erb
+++ b/jobs/syslog_storer/templates/syslog.apparmor.erb
@@ -1,0 +1,3 @@
+# syslog_storer rules
+    /var/vcap/store/syslog_storer/ rwl,
+    /var/vcap/store/syslog_storer/** rwk,


### PR DESCRIPTION
in nobel a new apparmor profile for rsyslog is now enabled by default preventing to write log files outside /var/log by adding this apparmor profile
would solve https://github.com/cloudfoundry/bosh-linux-stemcell-builder/issues/361

