### PR TITLE
tests: Increase timeouts for BOSH commands

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -13,5 +13,5 @@ bosh upload-stemcell "https://bosh.io/d/stemcells/bosh-google-kvm-${STEMCELL_OS}
 
 pushd "$(dirname "$0")/../tests"
   go install github.com/onsi/ginkgo/v2/ginkgo
-  ginkgo -r --procs="${NODES:-3}" --compilers="${NODES:-3}" --keep-going --timeout="2h" "$@"
+  ginkgo -r --procs="${NODES:-3}" --compilers="${NODES:-3}" --keep-going --timeout="4h" "$@"
 popd

--- a/tests/boshhelpers_test.go
+++ b/tests/boshhelpers_test.go
@@ -55,7 +55,7 @@ func Cleanup() {
 	By("Performing Cleanup")
 	BoshCmd("locks")
 	session := BoshCmd("delete-deployment")
-	Eventually(session, 10*time.Minute).Should(gexec.Exit(0))
+	Eventually(session, 20*time.Minute).Should(gexec.Exit(0))
 
 	Eventually(eventualLockChecker()).ShouldNot(gbytes.Say(DeploymentName()))
 }

--- a/tests/boshhelpers_test.go
+++ b/tests/boshhelpers_test.go
@@ -65,7 +65,7 @@ func Deploy(manifest string) *gexec.Session {
 	session := BoshCmd("deploy", manifest,
 		"-v", fmt.Sprintf("deployment=%s", DeploymentName()),
 		"-v", fmt.Sprintf("stemcell-os=%s", StemcellOS()))
-	Eventually(session, 10*time.Minute).Should(gexec.Exit(0))
+	Eventually(session, 20*time.Minute).Should(gexec.Exit(0))
 	Eventually(BoshCmd("locks")).ShouldNot(gbytes.Say(DeploymentName()))
 	return session
 }
@@ -74,7 +74,7 @@ func DeployWithVarsStore(manifest string) *gexec.Session {
 	session := BoshCmd("deploy", manifest,
 		"-v", fmt.Sprintf("deployment=%s", DeploymentName()), fmt.Sprintf("--vars-store=/tmp/%s-vars.yml", DeploymentName()),
 		"-v", fmt.Sprintf("stemcell-os=%s", StemcellOS()))
-	Eventually(session, 10*time.Minute).Should(gexec.Exit(0))
+	Eventually(session, 20*time.Minute).Should(gexec.Exit(0))
 	Eventually(BoshCmd("locks")).ShouldNot(gbytes.Say(DeploymentName()))
 	return session
 }


### PR DESCRIPTION
# Description

Doubles the timeouts for BOSH commands so that they have more time to succeed in CI, which is a bit more underpowered than before.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
