### PR TITLE
Fix header formatting in documentation

### DIFF
--- a/examples/example-custom-rules.md
+++ b/examples/example-custom-rules.md
@@ -65,7 +65,7 @@ if ($app-name != "uaa") then {
 }
 ```
 
-#Forwarding to additional remotes
+# Forwarding to additional remotes
 
 If you want to forward logs to remotes in addition to the remote set in the manifest,
 you can use the custom rule field to do so. To send all logs to additional remotes, 


### PR DESCRIPTION
# Description

One of the headers lacked a space between # and the Text, leading it to be rendered as normal text, not ad header.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
