### PR TITLE
Parse apparmor's rsyslogd profile after adding a new config

### DIFF
--- a/jobs/syslog_forwarder/templates/pre-start.erb
+++ b/jobs/syslog_forwarder/templates/pre-start.erb
@@ -17,6 +17,10 @@ rm -f /etc/rsyslog.d/rsyslog.conf /etc/rsyslog.d/*-syslog-release*conf
 
 if [ -d "/etc/apparmor.d/rsyslog.d/" ]; then
   cp $(dirname $0)/../config/syslog.apparmor /etc/apparmor.d/rsyslog.d/syslog.apparmor
+
+  if command -v apparmor_parser &>/dev/null && [ -f "/etc/apparmor.d/usr.sbin.rsyslogd" ]; then
+    apparmor_parser -r /etc/apparmor.d/usr.sbin.rsyslogd
+  fi
 fi
 
 <% unless p('syslog.migration.disabled') %>
@@ -47,4 +51,8 @@ chmod 0644 /etc/rsyslog.d/40-syslog-release-file-exclusion.conf
 
 <% end %>
 
-service rsyslog restart
+if command -v systemctl &>/dev/null; then
+  systemctl restart rsyslog
+else
+  service rsyslog restart
+fi

--- a/jobs/syslog_storer/templates/pre-start.erb
+++ b/jobs/syslog_storer/templates/pre-start.erb
@@ -10,5 +10,14 @@ mkdir -p /etc/rsyslog.d
 cp $(dirname $0)/../config/rsyslog.conf /etc/rsyslog.d/rsyslog.conf
 if [ -d "/etc/apparmor.d/rsyslog.d/" ]; then
   cp $(dirname $0)/../config/syslog.apparmor /etc/apparmor.d/rsyslog.d/syslog.apparmor
+
+  if command -v apparmor_parser &>/dev/null && [ -f "/etc/apparmor.d/usr.sbin.rsyslogd" ]; then
+    apparmor_parser -r /etc/apparmor.d/usr.sbin.rsyslogd
+  fi
 fi
-service rsyslog restart
+
+if command -v systemctl &>/dev/null; then
+  systemctl restart rsyslog
+else
+  service rsyslog restart
+fi


### PR DESCRIPTION
# Description

Due to the presence of `apparmor` in the `noble` stemcell, PR https://github.com/cloudfoundry/syslog-release/pull/212 was merged to update `apparmor`'s `rsyslogd` profile. When using that commit as the base for our `syslog-release`, we ran into an issue where `apparmor` had already started before the `pre-start` script finished, preventing it from making use of the added `syslog_forwarder` config. This PR adds a call to `apparmor_parser` to parse the `rsyslogd` profile after copying over the new config.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
