### PR TITLE
Check active init system

### DIFF
--- a/jobs/syslog_forwarder/templates/pre-start.erb
+++ b/jobs/syslog_forwarder/templates/pre-start.erb
@@ -51,7 +51,7 @@ chmod 0644 /etc/rsyslog.d/40-syslog-release-file-exclusion.conf
 
 <% end %>
 
-if command -v systemctl &>/dev/null; then
+if [ "$(cat /proc/1/comm 2>/dev/null)" = "systemd" ] && command -v systemctl &>/dev/null; then
   systemctl restart rsyslog
 else
   service rsyslog restart

--- a/jobs/syslog_storer/templates/pre-start.erb
+++ b/jobs/syslog_storer/templates/pre-start.erb
@@ -16,7 +16,7 @@ if [ -d "/etc/apparmor.d/rsyslog.d/" ]; then
   fi
 fi
 
-if command -v systemctl &>/dev/null; then
+if [ "$(cat /proc/1/comm 2>/dev/null)" = "systemd" ] && command -v systemctl &>/dev/null; then
   systemctl restart rsyslog
 else
   service rsyslog restart


### PR DESCRIPTION
# Description

Small addition to PR https://github.com/cloudfoundry/syslog-release/pull/216, verifying the init system to be `systemd` before using `systemctl`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
