### PR TITLE
Add AppArmor custom rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ If you have any questions, or want to get attention for a PR or issue please rea
     1. [Configure Forwarding](#configure-forwarding)
     1. [Message Size Limits](#message-size-limits)
     1. [Custom Rule](#custom-rule)
+    1. [Custom AppArmor Rules](#custom-apparmor-rules)
     1. [Test Store](#test-store)
 1. [Format](#format)
 1. [Tech Notes](#tech-notes)
@@ -119,6 +120,25 @@ We have some simple documentation with a few example rules in
 [`example-custom-rules.md`](examples/example-custom-rules.md).
 
 **Please note:** if your custom rule is invalid, the pre-start script will fail.
+
+### Custom AppArmor Rules
+
+Starting from Ubuntu Noble, the AppArmor profile for rsyslog is enforced. If you
+use plugins like `imfile` or need rsyslog to access log files outside of
+`/var/vcap/sys/log`, you may need to add extra AppArmor rules.
+
+Use the `syslog.custom_apparmor_rules` property to extend the AppArmor profile:
+
+```yml
+properties:
+  syslog:
+    custom_apparmor_rules: |
+      /var/vcap/data/syslog_forwarder/** rw,
+      /var/vcap/sys/log/syslog_forwarder/** rw,
+```
+
+**Note:** `/var/vcap/sys/log` is a symlink to `/var/vcap/data`, so both paths
+must be included in your rules.
 
 ### Test Store
 

--- a/examples/example-custom-rules.md
+++ b/examples/example-custom-rules.md
@@ -131,6 +131,12 @@ You can find config docs for RSYSLOG [here][rsyslog-config-docs].
 
 Docs for rainerscript can be found [here][rainerscript-docs].
 
+**Note:** This file covers the `syslog.custom_rule` property (rsyslog
+configuration). For extending the **AppArmor** profile (e.g., granting rsyslog
+access to additional paths on Ubuntu Noble+), see the
+[Custom AppArmor Rules](../README.md#custom-apparmor-rules) section in the
+README.
+
 [rainerscript-docs]: http://www.rsyslog.com/doc/v8-stable/rainerscript/index.html
 [rsyslog-config-docs]: http://www.rsyslog.com/doc/v8-stable/configuration/basic_structure.html
 [global-config-doc]: https://www.rsyslog.com/doc/v8-stable/configuration/global/index.html

--- a/jobs/syslog_forwarder/spec
+++ b/jobs/syslog_forwarder/spec
@@ -197,6 +197,25 @@ properties:
     default: 8k
     description: Sets the $MaxMessageSize configuration flag for rsyslog.
 
+  syslog.custom_apparmor_rules:
+    default: ""
+    description: |
+      Adds custom AppArmor rules at the end of syslog.apparmor.erb.
+      Starting from Ubuntu Noble, the AppArmor rules are enforced.
+      Because of that, some extra AppArmor read and write permissions might
+      be needed to get some Syslog parsing rules working, like for example
+      when using imfile or some extra paths to log files outside the "/var/vcap/sys/log" folder.
+      Please note that the following two things:
+      1. "/var/vcap/sys/log" is a symlink to "/var/vcap/data" and both paths
+      have to be added to the AppArmor rule.
+      2. As the files in "/var/vcap/sys/log" are tailed with blackbox, in case 
+      you use Syslog's imfile plugin, make sure that you are not duplicating logs.
+      Example:
+        syslog:
+          custom_apparmor_rules: |
+            /var/vcap/data/syslog_forwarder/** rw,
+            /var/vcap/sys/log/syslog_forwarder/** rw,
+
   logging.format.timestamp:
     description: "Format for timestamp in log file forwarder logs. Valid values are 'deprecated' and 'rfc3339'."
     default: "deprecated"

--- a/jobs/syslog_forwarder/templates/syslog.apparmor.erb
+++ b/jobs/syslog_forwarder/templates/syslog.apparmor.erb
@@ -3,3 +3,4 @@
     /var/vcap/jobs/syslog_forwarder/config/* r,
     /var/vcap/data/syslog_forwarder/** rw,
     /var/vcap/sys/log/syslog_forwarder/** rw,
+    <%= p('syslog.custom_apparmor_rules') if p('syslog.custom_apparmor_rules') %>


### PR DESCRIPTION
# Description

Starting from Ubuntu Noble a new AppArmor profile for RSyslogd is used which is enforced. This might cause some access permisson problems for some plugins like imfile in Syslog. On the other hand, if someone adds some custom rules and want to include some log files which are located in directories that are not covered with the current rules, they might need a way how to extend the AppArmor rules.

This change makes this configuration possible.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests
- Manually generated manifest and deployed on a landscape

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes