### PR TITLE
force rebuilding apparmor cache fix

### DIFF
--- a/jobs/syslog_forwarder/templates/pre-start.erb
+++ b/jobs/syslog_forwarder/templates/pre-start.erb
@@ -19,7 +19,7 @@ if [ -d "/etc/apparmor.d/rsyslog.d/" ]; then
   cp $(dirname $0)/../config/syslog.apparmor /etc/apparmor.d/rsyslog.d/syslog.apparmor
 
   if command -v apparmor_parser &>/dev/null && [ -f "/etc/apparmor.d/usr.sbin.rsyslogd" ]; then
-    apparmor_parser -r /etc/apparmor.d/usr.sbin.rsyslogd
+    apparmor_parser -r -T -W /etc/apparmor.d/usr.sbin.rsyslogd
   fi
 fi
 


### PR DESCRIPTION
# Description

AppArmor favors reading of cached rules instead of newly created files as it want to speed up restarts. This change forces skipping of reading cache when reloading the configuration and it writes the updated configuration to the cache for further restarts. This make the loading of the custom Syslog rules load properly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [x] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
