### PR TITLE
fail deploy when RELP transport is combined with TLS

### DIFF
--- a/jobs/syslog_forwarder/templates/syslog-release-forwarding-rules.conf.erb
+++ b/jobs/syslog_forwarder/templates/syslog-release-forwarding-rules.conf.erb
@@ -38,6 +38,7 @@ $ActionExecOnlyWhenPreviousIsSuspended on
           syslog_fallback_transport = fallback_server.fetch('transport')
         %>
         <% if syslog_fallback_transport == 'relp' %>
+        <% raise "TLS is not supported for RELP fallback servers. Change fallback transport to TCP, or disable syslog.tls_enabled." if p('syslog.tls_enabled') %>
 $ModLoad omrelp
 :omrelp:<%= syslog_fallback_address %>:<%= syslog_fallback_port %>;SyslogForwarderTemplate
         <% elsif syslog_fallback_transport == 'tcp' %>

--- a/jobs/syslog_forwarder/templates/syslog-release-forwarding-setup.conf.erb
+++ b/jobs/syslog_forwarder/templates/syslog-release-forwarding-setup.conf.erb
@@ -69,7 +69,10 @@ $ActionQueueType LinkedList            # Allocate on-demand
 <% if p('syslog.tls_enabled') %>
   <%
     if syslog_transport == 'udp'
-      raise "TLS is not supported with UDP. Change transport to TCP or RELP, or disable TLS."
+      raise "TLS is not supported with UDP. Change transport to TCP, or disable TLS."
+    end
+    if syslog_transport == 'relp'
+      raise "TLS is not supported with RELP in this release. Change transport to TCP, or disable TLS."
     end
     ca_cert_path = '/etc/ssl/certs/ca-certificates.crt'
 

--- a/tests/acceptance_test.go
+++ b/tests/acceptance_test.go
@@ -234,15 +234,20 @@ var _ = Describe("Forwarding loglines to a TCP syslog drain", func() {
 	})
 
 	Context("when TLS is configured over relp", func() {
-		BeforeEach(func() {
-			Cleanup()
-			DeployWithVarsStore("manifests/relp-tls.yml")
-		})
 		AfterEach(func() {
 			Cleanup()
 		})
 
-		TestSharedBehavior()
+		It("will fail the deploy, since RELP does not support TLS in this release", func() {
+			By("Deploying")
+
+			session := BoshCmd("deploy", "manifests/relp-tls.yml",
+				"-v", fmt.Sprintf("deployment=%s", DeploymentName()),
+				fmt.Sprintf("--vars-store=/tmp/%s-vars.yml", DeploymentName()),
+				"-v", fmt.Sprintf("stemcell-os=%s", StemcellOS()))
+			Eventually(session, 10*time.Minute).Should(gexec.Exit(1))
+			Eventually(BoshCmd("locks")).ShouldNot(gbytes.Say(DeploymentName()))
+		})
 	})
 
 	Context("when TLS is configured and mTLS is enforced", func() {

--- a/tests/manifests/relp-tls.yml
+++ b/tests/manifests/relp-tls.yml
@@ -25,6 +25,8 @@ instance_groups:
         release: syslog
         properties:
           syslog:
+            address: "storer.default.((deployment)).bosh"
+            port: 514
             transport: "relp"
             tls_enabled: true
             permitted_peer: "*.storer.default.((deployment)).bosh"


### PR DESCRIPTION
# Description

Fixes a security defect where `syslog_forwarder` configured with `transport: relp` and
`tls_enabled: true` would render and deploy successfully while silently shipping logs in
**cleartext**.

The `$ActionSendStreamDriver*` directives emitted when `tls_enabled` is true only configure
the netstream driver used by the `omfwd` module (TCP/UDP `@`/`@@` actions). They have no
effect on `omrelp`, which is rendered via legacy selector syntax
(`*.* :omrelp:<addr>:<port>;Template`) — a syntax form with no TLS parameters at all. RELP's
own TLS stack (librelp) can only be configured via RainerScript
(`action(type="omrelp", tls="on", ...)`), which this release doesn't use anywhere.

This PR adds a fail-fast guard — mirroring the existing UDP+TLS guard already in the
template — so `bosh deploy` now fails outright for this combination instead of quietly
running an insecure connection. The same guard is added for `fallback_servers` entries with
`transport: relp`, which had the identical hole.

Also fixes `tests/manifests/relp-tls.yml`, which omitted `syslog.address`/`syslog.port` and
therefore never actually exercised the `relp` transport (it silently fell back to the
storer link's default `tcp`) — meaning the RELP+TLS combination was previously untested
entirely.

Real RELP TLS support (converting the RELP forwarding rule to RainerScript, wiring cert
properties, reworking fallback-server chaining) is intentionally out of scope for this fix;
it's a larger feature-level change that isn't required to close this security exposure.
Can be introduced in future PR.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Note: this is technically breaking for anyone currently (mis)configured with
`transport: relp` + `tls_enabled: true` — their next deploy will now fail instead of
silently running in cleartext. That's the intended outcome.

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [X] Acceptance tests

`tests/acceptance_test.go`'s "when TLS is configured over relp" context now asserts that
`bosh deploy` fails (mirroring the existing `broken-rules.yml` invalid-config test) instead
of asserting successful log forwarding.

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [X] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
