### PR TITLE
make bpm optional

### DIFF
--- a/jobs/syslog_forwarder/monit
+++ b/jobs/syslog_forwarder/monit
@@ -1,9 +1,17 @@
 <% unless p('syslog.migration.disabled') %>
 <% if p('syslog.forward_files') %>
+<% if p('use_bpm') %>
 check process blackbox
   with pidfile /var/vcap/sys/run/bpm/syslog_forwarder/blackbox.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start syslog_forwarder -p blackbox"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop syslog_forwarder -p blackbox"
   group vcap
+<% else %>
+check process blackbox
+  with pidfile /var/vcap/sys/run/syslog_forwarder/blackbox/blackbox.pid
+  start program "/var/vcap/jobs/syslog_forwarder/bin/blackbox_ctl start"
+  stop program "/var/vcap/jobs/syslog_forwarder/bin/blackbox_ctl stop"
+  group vcap
+<% end %>
 <% end %>
 <% end %>

--- a/jobs/syslog_forwarder/spec
+++ b/jobs/syslog_forwarder/spec
@@ -3,6 +3,7 @@ name: syslog_forwarder
 
 templates:
   bpm.yml.erb: config/bpm.yml
+  blackbox_ctl.erb: bin/blackbox_ctl
   blackbox_config.yml.erb: config/blackbox_config.yml
   ca_cert.pem.erb: config/ca_cert.pem
   client.crt.erb: config/client.crt
@@ -219,3 +220,10 @@ properties:
   logging.format.timestamp:
     description: "Format for timestamp in log file forwarder logs. Valid values are 'deprecated' and 'rfc3339'."
     default: "deprecated"
+
+  use_bpm:
+    description: >
+      When true, run this job under BPM. BPM is required on Resolute Raccoon
+      stemcells; support for running without BPM will be removed in a future
+      version.
+    default: false

--- a/jobs/syslog_forwarder/templates/blackbox_ctl.erb
+++ b/jobs/syslog_forwarder/templates/blackbox_ctl.erb
@@ -1,0 +1,48 @@
+#!/bin/bash
+# vim: set ft=sh
+
+set -e
+
+RUN_DIR=/var/vcap/sys/run/syslog_forwarder/blackbox
+LOG_DIR=/var/vcap/sys/log/syslog_forwarder/blackbox
+PIDFILE=$RUN_DIR/blackbox.pid
+CONFIG_FILE=/var/vcap/jobs/syslog_forwarder/config/blackbox_config.yml
+
+case $1 in
+
+  start)
+    mkdir -p $RUN_DIR
+    chown -R vcap:vcap $RUN_DIR
+
+    mkdir -p $LOG_DIR
+    chown -R root:root $LOG_DIR
+
+    echo $$ > $PIDFILE
+
+    <% unless p('syslog.respect_file_permissions') %>
+      setcap cap_dac_read_search+ep /var/vcap/packages/blackbox/bin/blackbox
+    <% end %>
+    <% if p('syslog.blackbox.limit_cpu') %>
+      export GOMAXPROCS=1
+    <% end %>
+
+    exec chpst -u syslog:vcap /var/vcap/packages/blackbox/bin/blackbox \
+      -config=$CONFIG_FILE \
+      1>>$LOG_DIR/blackbox.stdout.log \
+      2>>$LOG_DIR/blackbox.stderr.log
+
+    ;;
+
+  stop)
+    if [ -f $PIDFILE ]; then
+      kill -9 `cat $PIDFILE` || true
+      rm -f $PIDFILE
+    fi
+    ;;
+
+  *)
+    echo "Usage: $0 {start|stop}"
+
+    ;;
+
+esac


### PR DESCRIPTION
requiring bpm breaks deployments where syslog is deployed as an add on

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests
- [x] manual verification

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [x] I have added testing for my changes