### PR TITLE
Fix app armour in docker, make acceptance tests pass on Resolute

### DIFF
--- a/jobs/syslog_forwarder/templates/pre-start.erb
+++ b/jobs/syslog_forwarder/templates/pre-start.erb
@@ -19,7 +19,18 @@ if [ -d "/etc/apparmor.d/rsyslog.d/" ]; then
   cp $(dirname $0)/../config/syslog.apparmor /etc/apparmor.d/rsyslog.d/syslog.apparmor
 
   if command -v apparmor_parser &>/dev/null && [ -f "/etc/apparmor.d/usr.sbin.rsyslogd" ]; then
-    apparmor_parser -r -T -W /etc/apparmor.d/usr.sbin.rsyslogd
+    # The Docker CPI's privileged containers ship the AppArmor userspace and profiles
+    # but leave securityfs unmounted, so apparmor_parser has no interface to load
+    # through and exits non-zero. Mount it ourselves when it is missing.
+    if [ ! -d "/sys/kernel/security/apparmor" ]; then
+      mount -t securityfs securityfs /sys/kernel/security || true
+    fi
+
+    # Still missing means AppArmor is genuinely unavailable here; skip the reload
+    # rather than failing pre-start.
+    if [ -d "/sys/kernel/security/apparmor" ]; then
+      apparmor_parser -r -T -W /etc/apparmor.d/usr.sbin.rsyslogd
+    fi
   fi
 fi
 

--- a/jobs/syslog_storer/templates/pre-start.erb
+++ b/jobs/syslog_storer/templates/pre-start.erb
@@ -12,7 +12,18 @@ if [ -d "/etc/apparmor.d/rsyslog.d/" ]; then
   cp $(dirname $0)/../config/syslog.apparmor /etc/apparmor.d/rsyslog.d/syslog.apparmor
 
   if command -v apparmor_parser &>/dev/null && [ -f "/etc/apparmor.d/usr.sbin.rsyslogd" ]; then
-    apparmor_parser -r /etc/apparmor.d/usr.sbin.rsyslogd
+    # The Docker CPI's privileged containers ship the AppArmor userspace and profiles
+    # but leave securityfs unmounted, so apparmor_parser has no interface to load
+    # through and exits non-zero. Mount it ourselves when it is missing.
+    if [ ! -d "/sys/kernel/security/apparmor" ]; then
+      mount -t securityfs securityfs /sys/kernel/security || true
+    fi
+
+    # Still missing means AppArmor is genuinely unavailable here; skip the reload
+    # rather than failing pre-start.
+    if [ -d "/sys/kernel/security/apparmor" ]; then
+      apparmor_parser -r /etc/apparmor.d/usr.sbin.rsyslogd
+    fi
   fi
 fi
 

--- a/scripts/test
+++ b/scripts/test
@@ -2,7 +2,19 @@
 
 set -euxo pipefail
 
-STEMCELL_OS="${STEMCELL_OS:-ubuntu-xenial}"
+STEMCELL_OS="${STEMCELL_OS:-ubuntu-resolute}"
+INFRASTRUCTURE="${INFRASTRUCTURE:-google-kvm}"
+
+# BPM is required on Resolute Raccoon. Older stemcells still exercise the
+# non-BPM path, which exists for add-on deployments. Set USE_BPM explicitly to
+# override this.
+if [ -z "${USE_BPM:-}" ]; then
+  case "${STEMCELL_OS}" in
+    *resolute*) USE_BPM=true  ;;
+    *)          USE_BPM=false ;;
+  esac
+fi
+export USE_BPM
 
 pushd "$(dirname "$0")/.."
   bosh create-release --force --version="$(date "+%s")"
@@ -10,9 +22,8 @@ pushd "$(dirname "$0")/.."
 popd
 
 bosh upload-release https://bosh.io/d/github.com/cloudfoundry/bpm-release
-bosh upload-stemcell "https://bosh.io/d/stemcells/bosh-google-kvm-${STEMCELL_OS}-go_agent"
+bosh upload-stemcell "https://bosh.io/d/stemcells/bosh-${INFRASTRUCTURE}-${STEMCELL_OS}"
 
 pushd "$(dirname "$0")/../tests"
-  go install github.com/onsi/ginkgo/v2/ginkgo
-  ginkgo -r --procs="${NODES:-3}" --compilers="${NODES:-3}" --keep-going --timeout="4h" "$@"
+  go run github.com/onsi/ginkgo/v2/ginkgo  -r --procs="${NODES:-3}" --compilers="${NODES:-3}" --keep-going --timeout="4h" "$@"
 popd

--- a/tests/acceptance_test.go
+++ b/tests/acceptance_test.go
@@ -3,7 +3,6 @@ package syslog_acceptance_test
 import (
 	"bufio"
 	"bytes"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -212,9 +211,7 @@ var _ = Describe("Forwarding loglines to a TCP syslog drain", func() {
 		It("will fail the pre-start script", func() {
 			By("Deploying")
 
-			session := BoshCmd("deploy", "manifests/broken-rules.yml",
-				"-v", fmt.Sprintf("deployment=%s", DeploymentName()),
-				"-v", fmt.Sprintf("stemcell-os=%s", StemcellOS()))
+			session := BoshCmd(DeployArgs("manifests/broken-rules.yml")...)
 			Eventually(session, 10*time.Minute).Should(gexec.Exit(1))
 			Eventually(BoshCmd("locks")).ShouldNot(gbytes.Say(DeploymentName()))
 		})
@@ -240,10 +237,7 @@ var _ = Describe("Forwarding loglines to a TCP syslog drain", func() {
 		It("will fail the deploy, since RELP does not support TLS in this release", func() {
 			By("Deploying")
 
-			session := BoshCmd("deploy", "manifests/relp-tls.yml",
-				"-v", fmt.Sprintf("deployment=%s", DeploymentName()),
-				fmt.Sprintf("--vars-store=/tmp/%s-vars.yml", DeploymentName()),
-				"-v", fmt.Sprintf("stemcell-os=%s", StemcellOS()))
+			session := BoshCmd(DeployWithVarsStoreArgs("manifests/relp-tls.yml")...)
 			Eventually(session, 10*time.Minute).Should(gexec.Exit(1))
 			Eventually(BoshCmd("locks")).ShouldNot(gbytes.Say(DeploymentName()))
 		})

--- a/tests/boshhelpers_test.go
+++ b/tests/boshhelpers_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,7 +23,29 @@ func StemcellOS() string {
 	if stemcellOS, stemcellEnvSet := os.LookupEnv("STEMCELL_OS"); stemcellEnvSet {
 		return stemcellOS
 	}
-	return "ubuntu-bionic"
+	return "ubuntu-resolute"
+}
+
+// UseBPM reports whether the forwarder should run blackbox under BPM. scripts/test
+// derives USE_BPM from the stemcell; unset means the non-BPM path.
+func UseBPM() bool {
+	useBPM, err := strconv.ParseBool(os.Getenv("USE_BPM"))
+	return err == nil && useBPM
+}
+
+func DeployArgs(manifest string) []string {
+	args := []string{"deploy", manifest,
+		"-v", fmt.Sprintf("deployment=%s", DeploymentName()),
+		"-v", fmt.Sprintf("stemcell-os=%s", StemcellOS())}
+	if UseBPM() {
+		args = append(args, "-o", "manifests/ops/use-bpm.yml")
+	}
+	return args
+}
+
+func DeployWithVarsStoreArgs(manifest string) []string {
+	return append(DeployArgs(manifest),
+		fmt.Sprintf("--vars-store=/tmp/%s-vars.yml", DeploymentName()))
 }
 
 func BoshCmd(args ...string) *gexec.Session {
@@ -62,18 +85,14 @@ func Cleanup() {
 
 func Deploy(manifest string) *gexec.Session {
 	By("Deploying")
-	session := BoshCmd("deploy", manifest,
-		"-v", fmt.Sprintf("deployment=%s", DeploymentName()),
-		"-v", fmt.Sprintf("stemcell-os=%s", StemcellOS()))
+	session := BoshCmd(DeployArgs(manifest)...)
 	Eventually(session, 40*time.Minute).Should(gexec.Exit(0))
 	Eventually(BoshCmd("locks")).ShouldNot(gbytes.Say(DeploymentName()))
 	return session
 }
 
 func DeployWithVarsStore(manifest string) *gexec.Session {
-	session := BoshCmd("deploy", manifest,
-		"-v", fmt.Sprintf("deployment=%s", DeploymentName()), fmt.Sprintf("--vars-store=/tmp/%s-vars.yml", DeploymentName()),
-		"-v", fmt.Sprintf("stemcell-os=%s", StemcellOS()))
+	session := BoshCmd(DeployWithVarsStoreArgs(manifest)...)
 	Eventually(session, 40*time.Minute).Should(gexec.Exit(0))
 	Eventually(BoshCmd("locks")).ShouldNot(gbytes.Say(DeploymentName()))
 	return session

--- a/tests/manifests/broken-rules.yml
+++ b/tests/manifests/broken-rules.yml
@@ -23,10 +23,10 @@ instance_groups:
         release: bpm
       - name: syslog_forwarder
         release: syslog
-    properties:
-      syslog:
-        custom_rule: |
-          if :invalid-property-accessor then $nonsense
+        properties:
+          syslog:
+            custom_rule: |
+              if :invalid-property-accessor then $nonsense
   - name: storer
     instances: 1
     vm_type: default

--- a/tests/manifests/debug-filtering.yml
+++ b/tests/manifests/debug-filtering.yml
@@ -23,9 +23,9 @@ instance_groups:
         release: bpm
       - name: syslog_forwarder
         release: syslog
-    properties:
-      syslog:
-        heuristically_filter_debug_messages: true
+        properties:
+          syslog:
+            heuristically_filter_debug_messages: true
   - name: storer
     instances: 1
     vm_type: default

--- a/tests/manifests/disabled-no-config.yml
+++ b/tests/manifests/disabled-no-config.yml
@@ -23,10 +23,10 @@ instance_groups:
         release: bpm
       - name: syslog_forwarder
         release: syslog
-    properties:
-      syslog:
-        migration:
-          disabled: true
+        properties:
+          syslog:
+            migration:
+              disabled: true
 update:
   canaries: 1
   max_in_flight: 1

--- a/tests/manifests/disabled.yml
+++ b/tests/manifests/disabled.yml
@@ -23,10 +23,10 @@ instance_groups:
         release: bpm
       - name: syslog_forwarder
         release: syslog
-    properties:
-      syslog:
-        migration:
-          disabled: true
+        properties:
+          syslog:
+            migration:
+              disabled: true
   - name: storer
     instances: 1
     vm_type: default

--- a/tests/manifests/environment-identifier.yml
+++ b/tests/manifests/environment-identifier.yml
@@ -23,9 +23,9 @@ instance_groups:
         release: bpm
       - name: syslog_forwarder
         release: syslog
-    properties:
-      syslog:
-        environment: "some-environment-identifier"
+        properties:
+          syslog:
+            environment: "some-environment-identifier"
   - name: storer
     instances: 1
     vm_type: default

--- a/tests/manifests/good-rules.yml
+++ b/tests/manifests/good-rules.yml
@@ -23,10 +23,10 @@ instance_groups:
         release: bpm
       - name: syslog_forwarder
         release: syslog
-    properties:
-      syslog:
-        custom_rule: |
-          if ($msg contains "DEBUG") then stop
+        properties:
+          syslog:
+            custom_rule: |
+              if ($msg contains "DEBUG") then stop
   - name: storer
     instances: 1
     vm_type: default

--- a/tests/manifests/ops/use-bpm.yml
+++ b/tests/manifests/ops/use-bpm.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=forwarder/jobs/name=syslog_forwarder/properties?/use_bpm
+  value: true

--- a/tests/manifests/tcp-blackbox.yml
+++ b/tests/manifests/tcp-blackbox.yml
@@ -23,10 +23,10 @@ instance_groups:
         release: bpm
       - name: syslog_forwarder
         release: syslog
-    properties:
-      syslog:
-        use_tcp_for_file_forwarding_local_transport: true
-        max_message_size: 2k
+        properties:
+          syslog:
+            use_tcp_for_file_forwarding_local_transport: true
+            max_message_size: 2k
   - name: storer
     instances: 1
     vm_type: default

--- a/tests/manifests/vcap-filtering.yml
+++ b/tests/manifests/vcap-filtering.yml
@@ -23,9 +23,9 @@ instance_groups:
         release: bpm
       - name: syslog_forwarder
         release: syslog
-    properties:
-      syslog:
-        filter_legacy_vcap_messages: true
+        properties:
+          syslog:
+            filter_legacy_vcap_messages: true
   - name: storer
     instances: 1
     vm_type: default


### PR DESCRIPTION
# Description

The BOSH Release Acceptance Tests recently bumped from an ancient syslog release to 12.3.27 to get the new BPM support for Resolute. This pulled in the App Armor changes introduced in #188. This was causing syslog to fail in our Docker CPI pipelines since apparmor was installed but /sys/kernel/security/apparmor was not mounted.

I've verified this change makes rsyslog actually work under the docker CPI, not just fail silently.

Along the way I also made the acceptance tests pass on Resolute, which required some changes to allow applying the bpm ops file on Resolute. I validated the tests pass on both Noble and Resolute on AWS. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Manual Verification
- [ ] Unit tests
- [ ] Integration tests
- [X] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes