### PR TITLE
Bump Go to 1.26

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module syslog_integration_tests
 
-go 1.25.0
+go 1.26
 
 require (
 	code.cloudfoundry.org/go-loggregator/v10 v10.3.1


### PR DESCRIPTION
Bumps the `go` directive to 1.26; Go 1.25 reached EOL on 2026-08-19, so we were shipping an EOL Go toolchain. `go mod tidy` run; vendored trees refreshed where applicable. CI / golangci-lint should be green.

🤖 Generated with Claude Code (Opus, claude-opus-latest). Human-reviewed before submitting.